### PR TITLE
Add typedoc generation check to test workflow and fix race conditions

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,8 +1,6 @@
 name: Version Update and publish to NPM
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       versionUpdateSignificance:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Run Tests
+name: Run Tests & TypeDoc Check
 
 on:
   push:
@@ -41,3 +41,5 @@ jobs:
         sleep 3
     - name: Run Tests
       run: npm run test
+    - name: Run Typedoc Check
+      run: npx typedoc --entryPointStrategy Expand src --tsconfig tsconfig.json

--- a/src/modules/foreign-calls.ts
+++ b/src/modules/foreign-calls.ts
@@ -3,6 +3,7 @@
 import { toFunctionSelector } from "viem"
 import {
     simulateContract,
+    waitForTransactionReceipt,
     writeContract, 
     readContract,
     Config
@@ -83,10 +84,13 @@ export const createForeignCall = async(
         }
     }
     if(addFC != null) {
-        await writeContract(config, {
+        const returnHash = await writeContract(config, {
             ...addFC.request,
             account
         });
+        await waitForTransactionReceipt(config, {
+            hash: returnHash,
+        })
         return addFC.result
         
     } 
@@ -144,12 +148,15 @@ export const updateForeignCall = async(
         }
     }
     if(addFC != null) {
-        await writeContract(config, {
+        const returnHash = await writeContract(config, {
             ...addFC.request,
             account
         });
-           let foreignCallResult = addFC.result as any
-           return foreignCallResult.foreignCallIndex
+        await waitForTransactionReceipt(config, {
+            hash: returnHash,
+        })
+        let foreignCallResult = addFC.result as any
+        return foreignCallResult.foreignCallIndex
     } 
     return -1
 }
@@ -186,10 +193,13 @@ export const deleteForeignCall = async(
     }
 
     if(addFC != null) {
-        await writeContract(config, {
+        const returnHash = await writeContract(config, {
             ...addFC.request,
             account
         });
+        await waitForTransactionReceipt(config, {
+            hash: returnHash,
+        })
     }
     
     return 0

--- a/src/modules/foreign-calls.ts
+++ b/src/modules/foreign-calls.ts
@@ -8,7 +8,7 @@ import {
     readContract,
     Config
 } from "@wagmi/core";
-import { account, getConfig } from "../../config"
+import { account } from "../../config"
 import { sleep } from "./contract-interaction-utils"
 import { parseForeignCallDefinition } from "./parser"
 import { RulesEngineComponentContract } from "./types"
@@ -221,18 +221,14 @@ export const getForeignCall = async(
     policyId: number, 
     foreignCallId: number): Promise<any | null> => {
     try {
-        const addFC = await simulateContract(config, {
+        const addFC = await readContract(config, {
             address: rulesEngineComponentContract.address,
             abi: rulesEngineComponentContract.abi,
             functionName: "getForeignCall",
             args: [ policyId, foreignCallId ],
         });
-        await readContract(config, {
-            ...addFC.request,
-            account
-        });
 
-        let foreignCallResult = addFC.result 
+        let foreignCallResult = addFC as any;
         return foreignCallResult;
     } catch (error) {
         console.error(error);
@@ -255,19 +251,14 @@ export const getAllForeignCalls = async(
     rulesEngineComponentContract: RulesEngineComponentContract, 
     policyId: number): Promise<any[] | null> => {
     try {
-        const addFC = await simulateContract(config, {
+        const addFC = await readContract(config, {
             address: rulesEngineComponentContract.address,
             abi: rulesEngineComponentContract.abi,
             functionName: "getAllForeignCalls",
             args: [ policyId ],
         });
-    
-        await readContract(config, {
-            ...addFC.request,
-            account
-        });
-
-        return addFC.result;
+        let foreignCallResult = addFC as any[];
+        return foreignCallResult;
     } catch (error) {
         console.error(error);
         return null;

--- a/src/modules/function-signatures.ts
+++ b/src/modules/function-signatures.ts
@@ -2,8 +2,8 @@
 import { toFunctionSelector } from "viem"
 import {
     simulateContract,
+    waitForTransactionReceipt,
     writeContract, 
-    readContract,
     Config
 } from "@wagmi/core";
 import { account, getConfig } from "../../config"
@@ -80,10 +80,13 @@ export const createFunctionSignature = async (
         }
     }
     if(addRule != null) {
-        await writeContract(config, {
+        const returnHash = await writeContract(config, {
             ...addRule.request,
             account
         });
+        await waitForTransactionReceipt(config, {
+            hash: returnHash,
+        })
 
         return addRule.result;
     }
@@ -118,10 +121,13 @@ export const deleteFunctionSignature = async (
     }
 
     if(addRule != null) {
-        await writeContract(config, {
+        const returnHash = await writeContract(config, {
             ...addRule.request,
             account
         });
+        await waitForTransactionReceipt(config, {
+            hash: returnHash,
+        })
 
         return addRule.result;
     }

--- a/src/modules/function-signatures.ts
+++ b/src/modules/function-signatures.ts
@@ -6,7 +6,7 @@ import {
     writeContract, 
     Config
 } from "@wagmi/core";
-import { account, getConfig } from "../../config"
+import { account } from "../../config"
 import { sleep } from "./contract-interaction-utils"
 import { parseFunctionArguments } from "./parser"
 import { RulesEngineComponentContract } from "./types"

--- a/src/modules/policy.ts
+++ b/src/modules/policy.ts
@@ -166,10 +166,13 @@ export const updatePolicy = async (config: Config,
             
         }
         if(updatePolicy != null) {
-            await writeContract(config, {
+            const returnHash = await writeContract(config, {
                 ...updatePolicy.request,
                 account
             });
+            await waitForTransactionReceipt(config, {
+                hash: returnHash,
+            })
     
             return updatePolicy.result;
         } 
@@ -205,10 +208,13 @@ export const applyPolicy = async(config: Config, rulesEnginePolicyContract: Rule
     }
 
     if(applyPolicy != null) {
-        await writeContract(config, {
+        const returnHash = await writeContract(config, {
         ...applyPolicy.request,
         account
         }) 
+        await waitForTransactionReceipt(config, {
+            hash: returnHash,
+        })
     }
     return applyPolicy.result
 }
@@ -235,10 +241,13 @@ export const deletePolicy = async(config: Config, rulesEnginePolicyContract: Rul
     }
 
     if(addFC != null) {
-        await writeContract(config, {
+        const returnHash = await writeContract(config, {
             ...addFC.request,
             account
         });
+        await waitForTransactionReceipt(config, {
+            hash: returnHash,
+        })
     }
     
     return 0

--- a/src/modules/policy.ts
+++ b/src/modules/policy.ts
@@ -9,7 +9,7 @@ import {
     writeContract
 } from "@wagmi/core";
 
-import { account, getConfig } from "../../config";
+import { account } from "../../config";
 import { parseForeignCallDefinition, parseTrackerSyntax, convertRuleStructToString, convertForeignCallStructsToStrings, convertTrackerStructsToStrings } from "./parser";
 import { RulesEnginePolicyContract, RulesEngineComponentContract, FCNameToID, TrackerDefinition, PolicyJSON, hexToFunctionSignature } from "./types";
 import { createForeignCall,getAllForeignCalls} from "./foreign-calls"

--- a/src/modules/rules-engine.ts
+++ b/src/modules/rules-engine.ts
@@ -23,7 +23,6 @@
 
 import { Address, getContract } from "viem"
 import { FCNameToID, hexToFunctionSignature, RulesEngineComponentABI, RulesEngineComponentContract, RulesEnginePolicyABI, RulesEnginePolicyContract, RuleStruct } from "./types"
-import { getConfig } from "../../config"
 import {createPolicy as createPolicyInternal,
      updatePolicy as updatePolicyInternal, 
     applyPolicy as applyPolicyInternal,

--- a/src/modules/rules.ts
+++ b/src/modules/rules.ts
@@ -8,7 +8,7 @@ import {
     Config
 } from "@wagmi/core";
 
-import { account, getConfig } from "../../config";
+import { account } from "../../config";
 import { buildAnEffectStruct, buildARuleStruct, sleep } from "./contract-interaction-utils";
 import { RulesEnginePolicyContract, FCNameToID, ruleJSON, RulesEngineComponentContract, RuleStruct, RuleStorageSet } from "./types";
 
@@ -192,22 +192,14 @@ export const deleteRule = async(config: Config, rulesEngineComponentContract: Ru
 export const getRule = async(config: Config, rulesEnginePolicyContract: RulesEnginePolicyContract, policyId: number, ruleId: number): Promise<RuleStruct | null> => {
     
     try {
-        const getRuleule = await simulateContract(config, {
+        const result = await readContract(config, {
             address: rulesEnginePolicyContract.address,
             abi: rulesEnginePolicyContract.abi,
             functionName: "getRule",
             args: [ policyId, ruleId],
         });
 
-        const returnHash = await writeContract(config, {
-            ...getRuleule.request,
-            account
-        });
-        await waitForTransactionReceipt(config, {
-            hash: returnHash,
-        })
-
-        let ruleResult = getRuleule.result as RuleStorageSet
+        let ruleResult = result as RuleStorageSet
         let ruleS = ruleResult.rule as RuleStruct
 
 
@@ -239,20 +231,14 @@ export const getRule = async(config: Config, rulesEnginePolicyContract: RulesEng
  */
 export const getAllRules = async(config: Config, rulesEnginePolicyContract: RulesEnginePolicyContract, policyId: number): Promise<any[] | null> => {
     try {
-        const retrieveTR = await simulateContract(config, {
+        const result = await readContract(config, {
             address: rulesEnginePolicyContract.address,
             abi: rulesEnginePolicyContract.abi,
             functionName: "getAllRules",
             args: [ policyId],
         });
-    
 
-        await readContract(config, {
-            ...retrieveTR.request,
-            account
-        });
-
-        let trackerResult = retrieveTR.result
+        let trackerResult = result as RuleStorageSet[];
         return trackerResult;
     } catch (error) {
         console.error(error);

--- a/src/modules/rules.ts
+++ b/src/modules/rules.ts
@@ -2,6 +2,7 @@
 import { hexToString } from "viem";
 import {
     simulateContract,
+    waitForTransactionReceipt,
     writeContract, 
     readContract,
     Config
@@ -80,10 +81,13 @@ export const createRule = async (config: Config, rulesEnginePolicyContract: Rule
         }
     }
     if(addRule != null) {
-        await writeContract(config, {
+        const returnHash =  await writeContract(config, {
             ...addRule.request,
             account
         });
+        await waitForTransactionReceipt(config, {
+            hash: returnHash,
+        })
         
         return addRule.result;
     } 
@@ -124,10 +128,13 @@ export const updateRule = async (config: Config, rulesEnginePolicyContract: Rule
         }
     }
     if(addRule != null) {
-        await writeContract(config, {
+        const returnHash = await writeContract(config, {
             ...addRule.request,
             account
         });
+        await waitForTransactionReceipt(config, {
+            hash: returnHash,
+        })
 
         return addRule.result;
     } 
@@ -162,10 +169,13 @@ export const deleteRule = async(config: Config, rulesEngineComponentContract: Ru
     }
 
     if(addFC != null) {
-        await writeContract(config, {
+        const returnHash = await writeContract(config, {
             ...addFC.request,
             account
         });
+        await waitForTransactionReceipt(config, {
+            hash: returnHash,
+        })
     }
     
     return 0
@@ -189,10 +199,13 @@ export const getRule = async(config: Config, rulesEnginePolicyContract: RulesEng
             args: [ policyId, ruleId],
         });
 
-        await writeContract(config, {
+        const returnHash = await writeContract(config, {
             ...getRuleule.request,
             account
         });
+        await waitForTransactionReceipt(config, {
+            hash: returnHash,
+        })
 
         let ruleResult = getRuleule.result as RuleStorageSet
         let ruleS = ruleResult.rule as RuleStruct

--- a/src/modules/trackers.ts
+++ b/src/modules/trackers.ts
@@ -1,6 +1,6 @@
 /// SPDX-License-Identifier: BUSL-1.1
 import { simulateContract, waitForTransactionReceipt, writeContract, readContract, Config } from "@wagmi/core";
-import { account, getConfig } from "../../config";
+import { account } from "../../config";
 import { sleep } from "./contract-interaction-utils";
 import { parseTrackerSyntax } from "./parser";
 import { RulesEngineComponentContract, trackerJSON, TrackerDefinition } from "./types";
@@ -184,20 +184,13 @@ export const getTracker = async (
   trackerId: number
 ): Promise<any | null> => {
   try {
-    const retrieveTR = await simulateContract(config, {
+    const retrieveTR = await readContract(config, {
       address: rulesEngineComponentContract.address,
       abi: rulesEngineComponentContract.abi,
       functionName: "getTracker",
       args: [policyId, trackerId],
     });
-
-    await readContract(config, {
-      ...retrieveTR.request,
-      account,
-    });
-
-    let trackerResult = retrieveTR.result;
-    return trackerResult;
+    return retrieveTR;
   } catch (error) {
     console.error(error);
     return null;
@@ -220,19 +213,14 @@ export const getAllTrackers = async (
   policyId: number
 ): Promise<any[] | null> => {
   try {
-    const retrieveTR = await simulateContract(config, {
+    const retrieveTR = await readContract(config, {
       address: rulesEngineComponentContract.address,
       abi: rulesEngineComponentContract.abi,
       functionName: "getAllTrackers",
       args: [policyId],
     });
 
-    await readContract(config, {
-      ...retrieveTR.request,
-      account,
-    });
-
-    let trackerResult = retrieveTR.result;
+    let trackerResult = retrieveTR as any[];
     return trackerResult;
   } catch (error) {
     console.error(error);

--- a/src/modules/trackers.ts
+++ b/src/modules/trackers.ts
@@ -1,5 +1,5 @@
 /// SPDX-License-Identifier: BUSL-1.1
-import { simulateContract, writeContract, readContract, Config } from "@wagmi/core";
+import { simulateContract, waitForTransactionReceipt, writeContract, readContract, Config } from "@wagmi/core";
 import { account, getConfig } from "../../config";
 import { sleep } from "./contract-interaction-utils";
 import { parseTrackerSyntax } from "./parser";
@@ -61,9 +61,12 @@ export const createTracker = async (
     }
   }
   if (addTR != null) {
-    await writeContract(config, {
+    const returnHash = await writeContract(config, {
       ...addTR.request,
       account,
+    });
+    await waitForTransactionReceipt(config, {
+      hash: returnHash,
     });
 
     let trackerResult = addTR.result;
@@ -109,10 +112,13 @@ export const updateTracker = async (
     }
   }
   if (addTR != null) {
-    await writeContract(config, {
+    const returnHash = await writeContract(config, {
       ...addTR.request,
       account,
     });
+    await waitForTransactionReceipt(config, {
+      hash: returnHash,
+    })
     return trackerId;
   }
   return -1;
@@ -149,10 +155,13 @@ export const deleteTracker = async (
   }
 
   if (addFC != null) {
-    await writeContract(config, {
+    const returnHash = await writeContract(config, {
       ...addFC.request,
       account,
     });
+    await waitForTransactionReceipt(config, {
+      hash: returnHash,
+    })
   }
 
   return 0;

--- a/tests/testOutput/UserContract.sol
+++ b/tests/testOutput/UserContract.sol
@@ -1,5 +1,6 @@
 /// SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.24;
+import "tests/testOutput/testFileA.sol";
 
 /**
  * @title ExampleUserContract Contract for Testing the Rules Engine
@@ -8,7 +9,7 @@ pragma solidity ^0.8.24;
  *              It provides a sample function that showcases how custom arguments can be sent to the Rules Engine.
  * 
  */
-contract ExampleUserContract {
+contract ExampleUserContract is RulesEngineClientCustom {
     /**
      * @notice Transfers a specified amount of tokens to a given address.
      * @dev This function allows transferring tokens to another address with an additional parameter.
@@ -17,7 +18,7 @@ contract ExampleUserContract {
      * @param somethingElse An additional parameter for custom logic (purpose not specified in the given code).
      * @return bool Returns true if the transfer is successful.
      */
-    function transfer(address to, uint256 value, uint256 somethingElse) public returns (bool) {
+    function transfer(address to, uint256 value, uint256 somethingElse) public checkRulesBeforetransfer(to, value, somethinElse) returns (bool) {
         somethingElse;
         to;
         value;

--- a/tests/testOutput/UserContract.sol
+++ b/tests/testOutput/UserContract.sol
@@ -1,6 +1,5 @@
 /// SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.24;
-import "tests/testOutput/testFileA.sol";
 
 /**
  * @title ExampleUserContract Contract for Testing the Rules Engine
@@ -9,7 +8,7 @@ import "tests/testOutput/testFileA.sol";
  *              It provides a sample function that showcases how custom arguments can be sent to the Rules Engine.
  * 
  */
-contract ExampleUserContract is RulesEngineClientCustom {
+contract ExampleUserContract {
     /**
      * @notice Transfers a specified amount of tokens to a given address.
      * @dev This function allows transferring tokens to another address with an additional parameter.
@@ -18,7 +17,7 @@ contract ExampleUserContract is RulesEngineClientCustom {
      * @param somethingElse An additional parameter for custom logic (purpose not specified in the given code).
      * @return bool Returns true if the transfer is successful.
      */
-    function transfer(address to, uint256 value, uint256 somethingElse) public checkRulesBeforetransfer(to, value, somethinElse) returns (bool) {
+    function transfer(address to, uint256 value, uint256 somethingElse) public returns (bool) {
         somethingElse;
         to;
         value;


### PR DESCRIPTION
Remove automatic npm publishing and add typedoc generation checks

- Removed the automatic publishing of the npm package on release creation
- Added a typedoc generation check to tests
- Fixed race conditions where the SDK returned before the Tx is completed
- Removed redundant simulateContract() + readContract() calls
- Fixed an issue where the SDK was using a writeContract call for a read function