### PR TITLE
added error type support

### DIFF
--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -263,4 +263,26 @@ export const PT = [
   { name: "bytes", enumeration: pTypeEnum.BYTES },
 ];
 
+export type ErrorType = "INPUT" | "CONTRACT_READ" | "CONTRACT_WRITE" | "COMPILATION";
+
+export type RulesError = {
+    errorType: ErrorType;
+    state: any;
+    message: string;
+}
+
+export type Left<T> = {
+    left: T;
+    right?: never;
+};
+
+export type Right<U> = {
+    right: U;
+    left?: never;
+};
+
+export type Either<T, U> = NonNullable<Left<T> | Right<U>>;
+
+export type UnwrapEither = <T, U>(e: Either<T, U>) => NonNullable<T | U>;
+
 export type Maybe<T> = NonNullable<T> | null;

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -1,10 +1,49 @@
+import { Either, Left, Right, UnwrapEither } from "./types";
+
 // Get a default encoded values string from a Calling Function
 export function getEncodedValues(callingFunction: string) {
-  // Extract content between parentheses
-  const match = callingFunction.match(/\(([^)]*)\)/);
+    // Extract content between parentheses
+    const match = callingFunction.match(/\(([^)]*)\)/);
 
-  // Return the matched group or empty string if no match
-  const encodedValues = match ? match[1] : "";
-
-  return encodedValues;
+    // Return the matched group or empty string if no match
+    const encodedValues = match ? match[1] : "";
 }
+
+export const unwrapEither: UnwrapEither = <T, U>({
+    left,
+    right,
+}: Either<T, U>) => {
+    if (right !== undefined && left !== undefined) {
+        throw new Error(
+            `Received both left and right values at runtime when opening an Either\nLeft: ${JSON.stringify(
+                left
+            )}\nRight: ${JSON.stringify(right)}`
+        );
+        /*
+         We're throwing in this function because this can only occur at runtime if something 
+         happens that the TypeScript compiler couldn't anticipate. That means the application
+         is in an unexpected state and we should terminate immediately.
+        */
+    }
+    if (left !== undefined) {
+        return left as NonNullable<T>; // Typescript is getting confused and returning this type as `T | undefined` unless we add the type assertion
+    }
+    if (right !== undefined) {
+        return right as NonNullable<U>;
+    }
+    throw new Error(
+        `Received no left or right values at runtime when opening Either`
+    );
+};
+
+export const isLeft = <T, U>(e: Either<T, U>): e is Left<T> => {
+    return e.left !== undefined;
+};
+
+export const isRight = <T, U>(e: Either<T, U>): e is Right<U> => {
+    return e.right !== undefined;
+};
+
+export const makeLeft = <T>(value: T): Left<T> => ({ left: value });
+
+export const makeRight = <U>(value: U): Right<U> => ({ right: value });

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -1,4 +1,6 @@
-import { Either, Left, Right, UnwrapEither } from "./types";
+import { Either, Left, Right, RulesError, UnwrapEither } from "./types";
+import { getAddress as _getAddress, Address, ethAddress } from 'viem';
+
 
 // Get a default encoded values string from a Calling Function
 export function getEncodedValues(callingFunction: string) {
@@ -47,3 +49,16 @@ export const isRight = <T, U>(e: Either<T, U>): e is Right<U> => {
 export const makeLeft = <T>(value: T): Left<T> => ({ left: value });
 
 export const makeRight = <U>(value: U): Right<U> => ({ right: value });
+
+export const getAddress = (address: string): Either<RulesError, Address> => {
+    try {
+        return makeRight(_getAddress(address));
+    } catch (error) {
+        const message = `Address "${address}" is invalid`
+        return makeLeft({
+            errorType: "INPUT",
+            state: { address },
+            message
+        });
+    }
+}

--- a/src/parsing/parser.ts
+++ b/src/parsing/parser.ts
@@ -268,7 +268,7 @@ export function parseForeignCallDefinition(
                 return makeLeft({
                     errorType: "INPUT",
                     state: { PT, syntax },
-                    message: "Unsupported return type"
+                    message: "Unsupported argument type"
                 })
             }
             for (var parameterType of PT) {
@@ -307,7 +307,6 @@ export function buildForeignCallList(condition: string): string[] {
     // Use a regular expression to find all FC expressions
     const fcRegex = /FC:[a-zA-Z]+[^\s]+/g;
     const matches = condition.matchAll(fcRegex);
-    let processedCondition = condition;
     var names: string[] = [];
     // Convert matches iterator to array to process all at once
     for (const match of matches) {

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -1,6 +1,6 @@
 /// SPDX-License-Identifier: BUSL-1.1
 import { expect, test } from "vitest";
-import { EffectType, pTypeEnum } from "../src/modules/types.js";
+import { EffectType, ForeignCallDefinition, pTypeEnum, TrackerDefinition } from "../src/modules/types.js";
 import {
   keccak256,
   hexToNumber,
@@ -19,6 +19,7 @@ import {
 } from "../src/parsing/parser.js";
 import { reverseParseRule } from "../src/parsing/reverse-parsing-logic.js";
 import { removeExtraParenthesis } from "../src/parsing/parsing-utilities.js";
+import { unwrapEither } from '../src/modules/utils.js';
 
 test("Evaluates a simple syntax string (using only values and operators)", () => {
   /**
@@ -755,13 +756,13 @@ test("Creates a simple uint256 tracker", () => {
         "name": "Simple Int Tracker",
         "type": "uint256",
         "initialValue": "14"
-        }`;
-  var retVal = parseTrackerSyntax(JSON.parse(str));
-  expect(retVal.name).toEqual("Simple Int Tracker");
-  expect(retVal.type).toEqual(pTypeEnum.UINT256);
-  expect(retVal.initialValue).toEqual(
-    encodeAbiParameters(parseAbiParameters("uint256"), [BigInt(14)])
-  );
+        }`
+  var retVal = unwrapEither(parseTrackerSyntax(JSON.parse(str))) as TrackerDefinition
+
+  expect(retVal.name).toEqual("Simple Int Tracker")
+  expect(retVal.type).toEqual(pTypeEnum.UINT256)
+  expect(retVal.initialValue).toEqual(encodeAbiParameters(
+    parseAbiParameters('uint256'), [BigInt(14)]))
 });
 
 test("Creates a simple bool tracker", () => {
@@ -769,13 +770,12 @@ test("Creates a simple bool tracker", () => {
         "name": "Simple bool Tracker",
         "type": "bool",
         "initialValue": "true"
-        }`;
-  var retVal = parseTrackerSyntax(JSON.parse(str));
-  expect(retVal.name).toEqual("Simple bool Tracker");
-  expect(retVal.type).toEqual(pTypeEnum.BOOL);
-  expect(retVal.initialValue).toEqual(
-    encodeAbiParameters(parseAbiParameters("uint256"), [BigInt(1)])
-  );
+        }`
+  var retVal = unwrapEither(parseTrackerSyntax(JSON.parse(str))) as TrackerDefinition
+  expect(retVal.name).toEqual("Simple bool Tracker")
+  expect(retVal.type).toEqual(pTypeEnum.BOOL)
+  expect(retVal.initialValue).toEqual(encodeAbiParameters(
+    parseAbiParameters('uint256'), [BigInt(1)]))
 });
 
 test('Reverse Interpretation for the: "Evaluates a simple syntax string (using AND + OR operators and function parameters)" test', () => {
@@ -838,15 +838,12 @@ test("Creates a simple address tracker", () => {
   "name": "Simple Address Tracker",
   "type": "address",
   "initialValue": "0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC"
-  }`;
-  var retVal = parseTrackerSyntax(JSON.parse(str));
-  expect(retVal.name).toEqual("Simple Address Tracker");
-  expect(retVal.type).toEqual(pTypeEnum.ADDRESS);
-  expect(retVal.initialValue).toEqual(
-    encodeAbiParameters(parseAbiParameters("address"), [
-      "0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC",
-    ])
-  );
+  }`
+  var retVal = unwrapEither(parseTrackerSyntax(JSON.parse(str))) as TrackerDefinition
+  expect(retVal.name).toEqual("Simple Address Tracker")
+  expect(retVal.type).toEqual(pTypeEnum.ADDRESS)
+  expect(retVal.initialValue).toEqual(encodeAbiParameters(
+    parseAbiParameters('address'), ['0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC']))
 });
 
 test("Creates a simple string tracker", () => {
@@ -854,13 +851,12 @@ test("Creates a simple string tracker", () => {
   "name": "Simple String Tracker",
   "type": "string",
   "initialValue": "test"
-  }`;
-  var retVal = parseTrackerSyntax(JSON.parse(str));
-  expect(retVal.name).toEqual("Simple String Tracker");
-  expect(retVal.type).toEqual(pTypeEnum.STRING);
-  expect(retVal.initialValue).toEqual(
-    encodeAbiParameters(parseAbiParameters("string"), ["test"])
-  );
+  }`
+  var retVal = unwrapEither(parseTrackerSyntax(JSON.parse(str))) as TrackerDefinition
+  expect(retVal.name).toEqual("Simple String Tracker")
+  expect(retVal.type).toEqual(pTypeEnum.STRING)
+  expect(retVal.initialValue).toEqual(encodeAbiParameters(
+    parseAbiParameters('string'), ['test']))
 });
 
 test("Tests unsupported type", () => {
@@ -883,7 +879,7 @@ test("Creates a simple foreign call", () => {
   "valuesToPass": "0, 1, 2"
   }`;
 
-  var retVal = parseForeignCallDefinition(JSON.parse(str));
+  var retVal = unwrapEither(parseForeignCallDefinition(JSON.parse(str))) as ForeignCallDefinition
   expect(retVal.name).toEqual("Simple Foreign Call");
   expect(retVal.address).toEqual(
     getAddress("0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC")
@@ -1733,12 +1729,12 @@ test("Evaluates a simple effect involving a tracker update (TRU))", () => {
   var expectedArray = ["PLH", 0, "N", 1n, "-", 0, 1, "TRU", 4, 2, 0];
 
   var ruleStringA = `{
-"condition": " value > 5 ",
-"positiveEffects": [" TRU:testOne -= 1 "],
-"negativeEffects": [],
-"callingFunction": "addValue(uint256 value, string info)",
-"encodedValues": "uint256 value, string info, address addr"
-}`;
+  "condition": " value > 5 ",
+  "positiveEffects": [" TRU:testOne -= 1 "],
+  "negativeEffects": [],
+  "callingFunction": "addValue(uint256 value, string info)",
+  "encodedValues": "uint256 value, string info, address addr"
+  }`;
 
   var str =
     "value > 5  --> TRU:testOne -= value --> addValue(uint256 value, string info, address addr)";
@@ -2298,7 +2294,7 @@ test("Creates a simple foreign call with a boolean return", () => {
   "valuesToPass": "0, 1, 2"
   }`;
 
-  var retVal = parseForeignCallDefinition(JSON.parse(str));
+  var retVal = unwrapEither(parseForeignCallDefinition(JSON.parse(str))) as ForeignCallDefinition
   expect(retVal.name).toEqual("Simple Foreign Call");
   expect(retVal.address).toEqual(
     getAddress("0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC")

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -1,6 +1,6 @@
 /// SPDX-License-Identifier: BUSL-1.1
 import { expect, test } from "vitest";
-import { EffectType, ForeignCallDefinition, pTypeEnum, TrackerDefinition } from "../src/modules/types.js";
+import { EffectType, ForeignCallDefinition, pTypeEnum, RulesError, TrackerDefinition } from "../src/modules/types.js";
 import {
   keccak256,
   hexToNumber,
@@ -865,9 +865,8 @@ test("Tests unsupported type", () => {
   "type": "book",
   "initialValue": "test"
   }`;
-  expect(() => parseTrackerSyntax(JSON.parse(str))).toThrowError(
-    "Unsupported type"
-  );
+  var retVal = unwrapEither(parseTrackerSyntax(JSON.parse(str))) as RulesError
+  expect(retVal.message).toEqual('Unsupported type')
 });
 
 test("Creates a simple foreign call", () => {
@@ -897,9 +896,8 @@ test("Tests incorrect format for address", () => {
   "valuesToPass": "0, 1, 2"
   }`;
 
-  expect(() => parseForeignCallDefinition(JSON.parse(str))).toThrowError(
-    'Address "test" is invalid'
-  );
+  var retVal = unwrapEither(parseForeignCallDefinition(JSON.parse(str))) as RulesError
+  expect(retVal.message).toEqual('Address "test" is invalid')
 });
 
 test("Tests unsupported return type", () => {
@@ -910,9 +908,8 @@ test("Tests unsupported return type", () => {
   "returnType": "notAnInt",
   "valuesToPass": "0, 1, 2"
   }`;
-  expect(() => parseForeignCallDefinition(JSON.parse(str))).toThrowError(
-    "Unsupported return type"
-  );
+  var retVal = unwrapEither(parseForeignCallDefinition(JSON.parse(str))) as RulesError
+  expect(retVal.message).toEqual('Unsupported return type')
 });
 
 test("Tests unsupported argument type", () => {
@@ -924,9 +921,8 @@ test("Tests unsupported argument type", () => {
     "valuesToPass": "0, 1, 2"
     }`;
 
-  expect(() => parseForeignCallDefinition(JSON.parse(str))).toThrowError(
-    "Unsupported argument type"
-  );
+  var retVal = unwrapEither(parseForeignCallDefinition(JSON.parse(str))) as RulesError
+  expect(retVal.message).toEqual('Unsupported argument type')
 });
 
 test("Evaluates a simple syntax string with a Foreign Call", () => {


### PR DESCRIPTION
added RulesError type
```
export type ErrorType = "INPUT" | "CONTRACT_READ" | "CONTRACT_WRITE" | "COMPILATION";

export type RulesError = {
    errorType: ErrorType;
    state: any;
    message: string;
}
```
- added type support for Left(error) and Right(success) as [described here](https://antman-does-software.com/stop-catching-errors-in-typescript-use-the-either-type-to-make-your-code-predictable)
- added a getAddress wrapper for viem getAddress to catch errors