### PR TITLE
added zod validators

### DIFF
--- a/src/codeGeneration/generate-solidity.ts
+++ b/src/codeGeneration/generate-solidity.ts
@@ -1,7 +1,9 @@
 /// SPDX-License-Identifier: BUSL-1.1
 import * as fs from "fs";
 import * as path from "path";
-import { PolicyJSON, ruleJSON } from "../modules/types";
+import { getRulesErrorMessages, validatePolicyJSON } from "../modules/validation";
+import { isLeft, unwrapEither } from "../modules/utils";
+
 
 /**
  * @file generateSolidity.ts
@@ -55,7 +57,11 @@ export function generateModifier(
   outputFileName: string
 ): void {
   var functionNames: String[] = [];
-  let policySyntax: PolicyJSON = JSON.parse(policyS);
+  const validatedPolicySyntax = validatePolicyJSON(policyS);
+  if (isLeft(validatedPolicySyntax)) {
+    throw new Error(getRulesErrorMessages(unwrapEither(validatedPolicySyntax)));
+  }
+  const policySyntax = unwrapEither(validatedPolicySyntax);
 
   var iter = 0;
   var count = 0;

--- a/src/modules/contract-interaction-utils.ts
+++ b/src/modules/contract-interaction-utils.ts
@@ -20,8 +20,6 @@ import {
   EffectStruct,
   EffectStructs,
   FCNameToID,
-  ForeignCallOnChain,
-  ruleJSON,
   RulesEngineAdminABI,
   RulesEngineAdminContract,
   RulesEngineComponentABI,
@@ -32,8 +30,7 @@ import {
   RulesEngineRulesContract,
   RuleStruct,
 } from "./types";
-import { getForeignCall } from "./foreign-calls";
-import { config } from "dotenv";
+import { RuleJSON } from "./validation";
 
 /**
  * @file ContractInteractionUtils.ts
@@ -131,7 +128,7 @@ export async function sleep(ms: number): Promise<void> {
  *          effect placeholders, and associated effects.
  */
 export function buildARuleStruct(
-  ruleSyntax: ruleJSON,
+  ruleSyntax: RuleJSON,
   foreignCallNameToID: FCNameToID[],
   effect: EffectStructs,
   trackerNameToID: FCNameToID[],
@@ -256,7 +253,7 @@ export function buildARuleStruct(
  * - `instructionSet`: The cleaned instruction set for the effect.
  */
 export function buildAnEffectStruct(
-  ruleSyntax: ruleJSON,
+  ruleSyntax: RuleJSON,
   trackerNameToID: FCNameToID[],
   foreignCallNameToID: FCNameToID[],
   encodedValues: string,

--- a/src/modules/foreign-calls.ts
+++ b/src/modules/foreign-calls.ts
@@ -19,14 +19,11 @@ import {
   TrackerOnChain,
   FCNameToID,
   RulesEnginePolicyContract,
-  foreignCallJSON,
-  callingFunctionJSON,
 } from "./types";
-import { isRight, unwrapEither } from "./utils";
 import { getAllTrackers, getTrackerMetadata } from "./trackers";
 import { getCallingFunctionMetadata } from "./calling-functions";
-import { isLeft, isRight, unwrapEither } from "./utils";
-import { getRulesErrorMessages, validateForeignCallJSON } from "./validation";
+import { isLeft, unwrapEither } from "./utils";
+import { CallingFunctionJSON, getRulesErrorMessages, validateForeignCallJSON } from "./validation";
 
 /**
  * @file ForeignCalls.ts
@@ -142,14 +139,14 @@ export const createForeignCall = async (
   if (isLeft(json)) {
     throw new Error(getRulesErrorMessages(unwrapEither(json)));
   }
-  const fcJSJON: foreignCallJSON = unwrapEither(json);
+  const fcJSON = unwrapEither(json);
   var iter = 1;
   var encodedValues: string[] = [];
   for (var mapp of callingFunctionMetadata) {
-    if (mapp.callingFunction.trim() == fcJSJON.callingFunction.trim()) {
-      var builtJSON: callingFunctionJSON = {
-        name: fcJSJON.callingFunction,
-        functionSignature: fcJSJON.callingFunction,
+    if (mapp.callingFunction.trim() == fcJSON.callingFunction) {
+      var builtJSON = {
+        name: fcJSON.callingFunction,
+        functionSignature: fcJSON.callingFunction,
         encodedValues: mapp.encodedValues,
       };
       encodedValues = parseCallingFunction(builtJSON);
@@ -158,7 +155,7 @@ export const createForeignCall = async (
     iter += 1;
   }
   const foreignCall = parseForeignCallDefinition(
-    fcJSJON,
+    fcJSON,
     fcMap,
     indexMap,
     encodedValues
@@ -298,12 +295,12 @@ export const updateForeignCall = async (
   if (isLeft(json)) {
     throw new Error(getRulesErrorMessages(unwrapEither(json)));
   }
-  const fcJSON: foreignCallJSON = unwrapEither(json);
+  const fcJSON = unwrapEither(json);
   var iter = 1;
   var encodedValues: string[] = [];
   for (var mapp of callingFunctionMetadata) {
     if (mapp.callingFunction.trim() == fcJSON.callingFunction.trim()) {
-      var builtJSON: callingFunctionJSON = {
+      var builtJSON: CallingFunctionJSON = {
         name: fcJSON.callingFunction,
         functionSignature: fcJSON.callingFunction,
         encodedValues: mapp.encodedValues,

--- a/src/modules/policy.ts
+++ b/src/modules/policy.ts
@@ -43,7 +43,8 @@ import {
   convertForeignCallStructsToStrings,
   convertTrackerStructsToStrings,
 } from "../parsing/reverse-parsing-logic";
-import { validatePolicyJSON } from "./validation";
+import { getRulesErrorMessages, validatePolicyJSON } from "./validation";
+import { isLeft, unwrapEither } from "./utils";
 
 /**
  * @file policy.ts
@@ -111,7 +112,11 @@ export const createPolicy = async (
   let policyId: number = addPolicy.result;
 
   if (policySyntax !== undefined) {
-    let policyJSON = validatePolicyJSON(policySyntax);
+    const validatedPolicyJSON = validatePolicyJSON(policySyntax);
+    if (isLeft(validatedPolicyJSON)) {
+      throw new Error(getRulesErrorMessages(unwrapEither(validatedPolicyJSON)));
+    }
+    const policyJSON = unwrapEither(validatedPolicyJSON);
 
     for (var callingFunctionJSON of policyJSON.CallingFunctions) {
       var callingFunction = callingFunctionJSON.functionSignature;

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -65,43 +65,6 @@ export type CallingFunctionHashMapping = {
   encodedValues: string;
 };
 
-export interface PolicyJSON {
-  Policy: string;
-  PolicyType: string;
-  CallingFunctions: callingFunctionJSON[];
-  ForeignCalls: foreignCallJSON[];
-  Trackers: trackerJSON[];
-  Rules: ruleJSON[];
-}
-
-export interface foreignCallJSON {
-  name: string;
-  function: string;
-  address: string;
-  returnType: string;
-  valuesToPass: string;
-  callingFunction: string;
-}
-
-export interface trackerJSON {
-  name: string;
-  type: string;
-  initialValue: string;
-}
-
-export interface ruleJSON {
-  condition: string;
-  positiveEffects: string[];
-  negativeEffects: string[];
-  callingFunction: string;
-}
-
-export interface callingFunctionJSON {
-  name: string;
-  functionSignature: string;
-  encodedValues: string;
-}
-
 export type Tuple = {
   i: string;
   s: string;
@@ -269,13 +232,7 @@ export const matchArray: string[] = [
 ];
 export const truMatchArray: string[] = ["+=", "-=", "*=", "/=", "="];
 export const operandArray: string[] = ["PLH", "N"];
-export const supportedTrackerTypes: string[] = [
-  "uint256",
-  "string",
-  "address",
-  "bytes",
-  "bool",
-];
+
 export enum pTypeEnum {
   ADDRESS = 0,
   STRING = 1,

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -1,5 +1,5 @@
 import { Either, Left, Right, RulesError, UnwrapEither } from "./types";
-import { getAddress as _getAddress, Address, ethAddress } from 'viem';
+import { getAddress as _getAddress, isAddress as _isAddress } from 'viem';
 import { v4 as uuidv4 } from 'uuid';
 
 
@@ -50,18 +50,5 @@ export const isRight = <T, U>(e: Either<T, U>): e is Right<U> => {
 export const makeLeft = <T>(value: T): Left<T> => ({ left: value });
 
 export const makeRight = <U>(value: U): Right<U> => ({ right: value });
-
-export const getAddress = (address: string): Either<RulesError, Address> => {
-    try {
-        return makeRight(_getAddress(address));
-    } catch (error) {
-        const message = `Address "${address}" is invalid`
-        return makeLeft({
-            errorType: "INPUT",
-            state: { address },
-            message
-        });
-    }
-}
 
 export const getRandom = () => uuidv4();

--- a/src/modules/validation.ts
+++ b/src/modules/validation.ts
@@ -1,48 +1,59 @@
 import { z } from "zod/v4";
-import { Either, RulesError } from "./types";
+import { Either, PT, RulesError } from "./types";
 import { isLeft, makeLeft, makeRight, unwrapEither } from "./utils";
+import { Address, checksumAddress, isAddress } from "viem";
+
+const trimPossibleString = (input: any): any => {
+    if (typeof input === "string") {
+        return input.trim()
+    } else {
+        return input
+    }
+}
 
 const safeParseJson = (input: string): Either<RulesError[], object> => {
-  try {
-    const result = JSON.parse(input);
-    return makeRight(result);
-  } catch (error) {
-    return makeLeft([
-      {
-        errorType: "INPUT",
-        state: { input },
-        message: "Failed to parse JSON",
-      },
-    ]);
-  }
+    try {
+        const result = JSON.parse(input);
+        return makeRight(result);
+    } catch (error) {
+        return makeLeft([
+            {
+                errorType: "INPUT",
+                state: { input },
+                message: "Failed to parse JSON",
+            },
+        ]);
+    }
 };
 
 const ruleValidator = z.object({
-  condition: z.string(),
-  positiveEffects: z.array(z.string()),
-  negativeEffects: z.array(z.string()),
-  callingFunction: z.string(),
+    condition: z.string(),
+    positiveEffects: z.array(z.string()),
+    negativeEffects: z.array(z.string()),
+    callingFunction: z.string(),
 });
 
-export interface ruleJSON extends z.infer<typeof ruleValidator> {}
+export const getRulesErrorMessages = (errors: RulesError[]): string => {
+    console.log(errors[0])
+    return errors.map(err => `${err.message}`).join("\n");
+}
+export interface RuleJSON extends z.infer<typeof ruleValidator> { }
 
-export const validateRuleJSON = (
-  rule: string
-): Either<RulesError[], ruleJSON> => {
-  const parsedJson = safeParseJson(rule);
+export const validateRuleJSON = (rule: string): Either<RulesError[], RuleJSON> => {
+    const parsedJson = safeParseJson(rule);
 
-  if (isLeft(parsedJson)) return parsedJson;
+    if (isLeft(parsedJson)) return parsedJson;
 
-  const parsed = ruleValidator.safeParse(unwrapEither(parsedJson));
+    const parsed = ruleValidator.safeParse(unwrapEither(parsedJson));
 
-  if (parsed.success) {
-    return makeRight(parsed.data);
-  } else {
-    const errors: RulesError[] = parsed.error.issues.map((err) => ({
-      errorType: "INPUT",
-      message: `Error: ${err.message}: Field ${err.path.join(".")}`,
-      state: { input: rule },
-    }));
-    return makeLeft(errors);
-  }
+    if (parsed.success) {
+        return makeRight(parsed.data);
+    } else {
+        const errors: RulesError[] = parsed.error.issues.map((err) => ({
+            errorType: "INPUT",
+            message: `Error: ${err.message}: Field ${err.path.join(".")}`,
+            state: { input: rule },
+        }));
+        return makeLeft(errors);
+    }
 };

--- a/src/modules/validation.ts
+++ b/src/modules/validation.ts
@@ -16,13 +16,11 @@ const safeParseJson = (input: string): Either<RulesError[], object> => {
         const result = JSON.parse(input);
         return makeRight(result);
     } catch (error) {
-        return makeLeft([
-            {
-                errorType: "INPUT",
-                state: { input },
-                message: "Failed to parse JSON",
-            },
-        ]);
+        return makeLeft([{
+            errorType: "INPUT",
+            state: { input },
+            message: "Failed to parse JSON",
+        }]);
     }
 };
 
@@ -49,10 +47,189 @@ export const validateRuleJSON = (rule: string): Either<RulesError[], RuleJSON> =
     if (parsed.success) {
         return makeRight(parsed.data);
     } else {
-        const errors: RulesError[] = parsed.error.issues.map((err) => ({
+        const errors: RulesError[] = parsed.error.issues.map(err => ({
             errorType: "INPUT",
-            message: `Error: ${err.message}: Field ${err.path.join(".")}`,
+            message: `${err.message}: Field ${err.path.join('.')}`,
             state: { input: rule },
+        }));
+        return makeLeft(errors);
+    }
+};
+
+export const PType = PT.map((p) => p.name); // ["address", "string", "uint256", "bool", "void", "bytes"]
+
+export const splitFunctionInput = (input: string): string[] => {
+    return input
+        .split("(")[1]
+        .split(")")[0]
+        .split(",");
+}
+
+export const validateFCFuncionInput = (input: string): boolean => {
+    const parameterSplit = splitFunctionInput(input);
+
+    return parameterSplit.filter(
+        (parameter) => !PType.includes(parameter.trim())
+    ).length === 0;
+}
+
+export const foreignCallValidator = z.object({
+    name: z.string(),
+    function: z.string()
+        .trim()
+        .refine(
+            validateFCFuncionInput,
+            { message: "Unsupported argument type" }
+        ),
+    address: z.string()
+        .trim()
+        .refine((input) => isAddress(input), {
+            message: `Address is invalid`,
+        })
+        .transform((input) => checksumAddress(input.trim() as Address)),
+    returnType: z.preprocess(trimPossibleString, z.literal(PType, "Unsupported return type")),
+    valuesToPass: z.string()
+        .trim(),
+    callingFunction: z.string()
+        .trim()
+
+});
+
+export interface ForeignCallJSON extends z.infer<typeof foreignCallValidator> { }
+
+export const validateForeignCallJSON = (foreignCall: string): Either<RulesError[], ForeignCallJSON> => {
+    const parsedJson = safeParseJson(foreignCall);
+
+    if (isLeft(parsedJson)) return parsedJson;
+
+    const parsed = foreignCallValidator.safeParse(unwrapEither(parsedJson));
+
+    if (parsed.success) {
+        return makeRight(parsed.data);
+    } else {
+        const errors: RulesError[] = parsed.error.issues.map(err => ({
+            errorType: "INPUT",
+            message: `${err.message}: Field ${err.path.join('.')}`,
+            state: { input: foreignCall },
+        }));
+        return makeLeft(errors);
+    }
+};
+
+export const supportedTrackerTypes: string[] = [
+    "uint256",
+    "string",
+    "address",
+    "bytes",
+    "bool",
+];
+
+export const trackerType = z.discriminatedUnion("type", [
+    z.object({ type: z.literal("uint256"), initialValue: z.number() }),
+    z.object({ type: z.literal("string"), initialValue: z.string() }),
+    z.object({ type: z.literal("address"), initialValue: z.string() }),
+    z.object({ type: z.literal("bytes"), initialValue: z.string() }),
+    z.object({ type: z.literal("bool"), initialValue: z.literal(["true", "false"]) }),
+])
+
+const validateTrackerValue = (data: any) => {
+    // Validate that the initialValue matches the type
+    switch (data.type) {
+        case "uint256":
+            return !isNaN(Number(data.initialValue));
+        case "string":
+            return typeof data.initialValue === "string";
+        case "address":
+            return isAddress(data.initialValue);
+        case "bytes":
+            return typeof data.initialValue === "string"; // Assuming bytes are represented as hex strings
+        case "bool":
+            return true;
+        default:
+            return false; // Should never happen due to z.literal
+    }
+}
+
+export const trackerValidator = z.object({
+    name: z.string()
+        .trim(),
+    type: z.preprocess(trimPossibleString, z.literal(supportedTrackerTypes, "Unsupported type")),
+    initialValue: z.string()
+        .trim()
+}).refine(validateTrackerValue, {
+    message: "Initial Value doesn't match type",
+});
+
+export interface TrackerJSON extends z.infer<typeof trackerValidator> { }
+
+export const validateTrackerJSON = (tracker: string): Either<RulesError[], TrackerJSON> => {
+    const parsedJson = safeParseJson(tracker);
+
+    if (isLeft(parsedJson)) return parsedJson;
+
+    const parsed = trackerValidator.safeParse(unwrapEither(parsedJson));
+
+    if (parsed.success) {
+        return makeRight(parsed.data);
+    } else {
+        const errors: RulesError[] = parsed.error.issues.map(err => ({
+            errorType: "INPUT",
+            message: `${err.message}: Field ${err.path.join('.')}`,
+            state: { input: tracker },
+        }));
+        return makeLeft(errors);
+    }
+};
+
+export const callingFunctionValidator = z.object({
+    name: z.string()
+        .trim(),
+    functionSignature: z.string()
+        .trim(),
+    encodedValues: z.string()
+        .trim()
+});
+
+export interface CallingFunctionJSON extends z.infer<typeof callingFunctionValidator> { }
+export const validateCallingFunctionJSON = (callingFunction: string): Either<RulesError[], CallingFunctionJSON> => {
+    const parsedJson = safeParseJson(callingFunction);
+    if (isLeft(parsedJson)) return parsedJson;
+    const parsed = callingFunctionValidator.safeParse(unwrapEither(parsedJson));
+    if (parsed.success) {
+        return makeRight(parsed.data);
+    } else {
+        const errors: RulesError[] = parsed.error.issues.map(err => ({
+            errorType: "INPUT",
+            message: `${err.message}: Field ${err.path.join('.')}`,
+            state: { input: callingFunction },
+        }));
+        return makeLeft(errors);
+    }
+};
+
+export const policyJSONValidator = z.object({
+    Policy: z.string(),
+    PolicyType: z.string(),
+    CallingFunctions: z.array(callingFunctionValidator),
+    ForeignCalls: z.array(foreignCallValidator),
+    Trackers: z.array(trackerValidator),
+    Rules: z.array(ruleValidator),
+});
+export interface PolicyJSON extends z.infer<typeof policyJSONValidator> { }
+export const validatePolicyJSON = (policy: string): Either<RulesError[], PolicyJSON> => {
+    const parsedJson = safeParseJson(policy);
+
+    if (isLeft(parsedJson)) return parsedJson;
+
+    const parsed = policyJSONValidator.safeParse(unwrapEither(parsedJson));
+
+    if (parsed.success) {
+        return makeRight(parsed.data);
+    } else {
+        const errors: RulesError[] = parsed.error.issues.map(err => ({
+            errorType: "INPUT",
+            message: `${err.message}: Field ${err.path.join('.')}`,
+            state: { input: policy },
         }));
         return makeLeft(errors);
     }

--- a/src/modules/validation.ts
+++ b/src/modules/validation.ts
@@ -11,11 +11,11 @@ import { Address, checksumAddress, isAddress } from "viem";
  * @returns The trimmed input or the original input if not a string.
  */
 const trimPossibleString = (input: any): any => {
-	if (typeof input === "string") {
-		return input.trim()
-	} else {
-		return input
-	}
+  if (typeof input === "string") {
+    return input.trim()
+  } else {
+    return input
+  }
 }
 
 /**
@@ -25,25 +25,25 @@ const trimPossibleString = (input: any): any => {
  * @returns Either the parsed string or an error.
  */
 export const safeParseJson = (input: string): Either<RulesError[], object> => {
-	try {
-		const result = JSON.parse(input);
-		return makeRight(result);
-	} catch (error) {
-		return makeLeft([{
-			errorType: "INPUT",
-			state: { input },
-			message: "Failed to parse JSON",
-		}]);
-	}
+  try {
+    const result = JSON.parse(input);
+    return makeRight(result);
+  } catch (error) {
+    return makeLeft([{
+      errorType: "INPUT",
+      state: { input },
+      message: "Failed to parse JSON",
+    }]);
+  }
 };
 
 export const PType = PT.map((p) => p.name); // ["address", "string", "uint256", "bool", "void", "bytes"]
 
 export const splitFunctionInput = (input: string): string[] => {
-	return input
-		.split("(")[1]
-		.split(")")[0]
-		.split(",");
+  return input
+    .split("(")[1]
+    .split(")")[0]
+    .split(",");
 }
 
 /**
@@ -53,16 +53,16 @@ export const splitFunctionInput = (input: string): string[] => {
  * @returns The errors messages concatenated into a single string
  */
 export const getRulesErrorMessages = (errors: RulesError[]): string => {
-	console.log(errors[0])
-	return errors.map(err => `${err.message}`).join("\n");
+  console.log(errors[0])
+  return errors.map(err => `${err.message}`).join("\n");
 }
 
 
 const ruleValidator = z.object({
-	condition: z.string(),
-	positiveEffects: z.array(z.string()),
-	negativeEffects: z.array(z.string()),
-	callingFunction: z.string(),
+  condition: z.string(),
+  positiveEffects: z.array(z.string()),
+  negativeEffects: z.array(z.string()),
+  callingFunction: z.string(),
 });
 export interface RuleJSON extends z.infer<typeof ruleValidator> { }
 
@@ -73,22 +73,22 @@ export interface RuleJSON extends z.infer<typeof ruleValidator> { }
  * @returns Either the parsed RuleJSON object or an error.
  */
 export const validateRuleJSON = (rule: string): Either<RulesError[], RuleJSON> => {
-	const parsedJson = safeParseJson(rule);
+  const parsedJson = safeParseJson(rule);
 
-	if (isLeft(parsedJson)) return parsedJson;
+  if (isLeft(parsedJson)) return parsedJson;
 
-	const parsed = ruleValidator.safeParse(unwrapEither(parsedJson));
+  const parsed = ruleValidator.safeParse(unwrapEither(parsedJson));
 
-	if (parsed.success) {
-		return makeRight(parsed.data);
-	} else {
-		const errors: RulesError[] = parsed.error.issues.map(err => ({
-			errorType: "INPUT",
-			message: `${err.message}: Field ${err.path.join('.')}`,
-			state: { input: rule },
-		}));
-		return makeLeft(errors);
-	}
+  if (parsed.success) {
+    return makeRight(parsed.data);
+  } else {
+    const errors: RulesError[] = parsed.error.issues.map(err => ({
+      errorType: "INPUT",
+      message: `${err.message}: Field ${err.path.join('.')}`,
+      state: { input: rule },
+    }));
+    return makeLeft(errors);
+  }
 };
 
 /**
@@ -98,32 +98,32 @@ export const validateRuleJSON = (rule: string): Either<RulesError[], RuleJSON> =
  * @returns true if input is valid, false if input is invalid.
  */
 export const validateFCFunctionInput = (input: string): boolean => {
-	const parameterSplit = splitFunctionInput(input);
+  const parameterSplit = splitFunctionInput(input);
 
-	return parameterSplit.filter(
-		(parameter) => !PType.includes(parameter.trim())
-	).length === 0;
+  return parameterSplit.filter(
+    (parameter) => !PType.includes(parameter.trim())
+  ).length === 0;
 }
 
 export const foreignCallValidator = z.object({
-	name: z.string(),
-	function: z.string()
-		.trim()
-		.refine(
-			validateFCFunctionInput,
-			{ message: "Unsupported argument type" }
-		),
-	address: z.string()
-		.trim()
-		.refine((input) => isAddress(input), {
-			message: `Address is invalid`,
-		})
-		.transform((input) => checksumAddress(input.trim() as Address)),
-	returnType: z.preprocess(trimPossibleString, z.literal(PType, "Unsupported return type")),
-	valuesToPass: z.string()
-		.trim(),
-	callingFunction: z.string()
-		.trim()
+  name: z.string(),
+  function: z.string()
+    .trim()
+    .refine(
+      validateFCFunctionInput,
+      { message: "Unsupported argument type" }
+    ),
+  address: z.string()
+    .trim()
+    .refine((input) => isAddress(input), {
+      message: `Address is invalid`,
+    })
+    .transform((input) => checksumAddress(input.trim() as Address)),
+  returnType: z.preprocess(trimPossibleString, z.literal(PType, "Unsupported return type")),
+  valuesToPass: z.string()
+    .trim(),
+  callingFunction: z.string()
+    .trim()
 
 });
 
@@ -136,30 +136,30 @@ export interface ForeignCallJSON extends z.infer<typeof foreignCallValidator> { 
  * @returns Either the parsed ForeignCallJSON object or an error.
  */
 export const validateForeignCallJSON = (foreignCall: string): Either<RulesError[], ForeignCallJSON> => {
-	const parsedJson = safeParseJson(foreignCall);
+  const parsedJson = safeParseJson(foreignCall);
 
-	if (isLeft(parsedJson)) return parsedJson;
+  if (isLeft(parsedJson)) return parsedJson;
 
-	const parsed = foreignCallValidator.safeParse(unwrapEither(parsedJson));
+  const parsed = foreignCallValidator.safeParse(unwrapEither(parsedJson));
 
-	if (parsed.success) {
-		return makeRight(parsed.data);
-	} else {
-		const errors: RulesError[] = parsed.error.issues.map(err => ({
-			errorType: "INPUT",
-			message: `${err.message}: Field ${err.path.join('.')}`,
-			state: { input: foreignCall },
-		}));
-		return makeLeft(errors);
-	}
+  if (parsed.success) {
+    return makeRight(parsed.data);
+  } else {
+    const errors: RulesError[] = parsed.error.issues.map(err => ({
+      errorType: "INPUT",
+      message: `${err.message}: Field ${err.path.join('.')}`,
+      state: { input: foreignCall },
+    }));
+    return makeLeft(errors);
+  }
 };
 
 export const supportedTrackerTypes: string[] = [
-	"uint256",
-	"string",
-	"address",
-	"bytes",
-	"bool",
+  "uint256",
+  "string",
+  "address",
+  "bytes",
+  "bool",
 ];
 
 /**
@@ -169,31 +169,31 @@ export const supportedTrackerTypes: string[] = [
  * @returns true if input is valid, false if input is invalid.
  */
 const validateTrackerValue = (data: any) => {
-	// Validate that the initialValue matches the type
-	switch (data.type) {
-		case "uint256":
-			return !isNaN(Number(data.initialValue));
-		case "string":
-			return typeof data.initialValue === "string";
-		case "address":
-			return isAddress(data.initialValue);
-		case "bytes":
-			return typeof data.initialValue === "string"; // Assuming bytes are represented as hex strings
-		case "bool":
-			return true;
-		default:
-			return false; // Should never happen due to z.literal
-	}
+  // Validate that the initialValue matches the type
+  switch (data.type) {
+    case "uint256":
+      return !isNaN(Number(data.initialValue));
+    case "string":
+      return typeof data.initialValue === "string";
+    case "address":
+      return isAddress(data.initialValue);
+    case "bytes":
+      return typeof data.initialValue === "string"; // Assuming bytes are represented as hex strings
+    case "bool":
+      return true;
+    default:
+      return false; // Should never happen due to z.literal
+  }
 }
 
 export const trackerValidator = z.object({
-	name: z.string()
-		.trim(),
-	type: z.preprocess(trimPossibleString, z.literal(supportedTrackerTypes, "Unsupported type")),
-	initialValue: z.string()
-		.trim()
+  name: z.string()
+    .trim(),
+  type: z.preprocess(trimPossibleString, z.literal(supportedTrackerTypes, "Unsupported type")),
+  initialValue: z.string()
+    .trim()
 }).refine(validateTrackerValue, {
-	message: "Initial Value doesn't match type",
+  message: "Initial Value doesn't match type",
 });
 
 export interface TrackerJSON extends z.infer<typeof trackerValidator> { }
@@ -205,31 +205,31 @@ export interface TrackerJSON extends z.infer<typeof trackerValidator> { }
  * @returns Either the parsed TrackerJSON object or an error.
  */
 export const validateTrackerJSON = (tracker: string): Either<RulesError[], TrackerJSON> => {
-	const parsedJson = safeParseJson(tracker);
+  const parsedJson = safeParseJson(tracker);
 
-	if (isLeft(parsedJson)) return parsedJson;
+  if (isLeft(parsedJson)) return parsedJson;
 
-	const parsed = trackerValidator.safeParse(unwrapEither(parsedJson));
+  const parsed = trackerValidator.safeParse(unwrapEither(parsedJson));
 
-	if (parsed.success) {
-		return makeRight(parsed.data);
-	} else {
-		const errors: RulesError[] = parsed.error.issues.map(err => ({
-			errorType: "INPUT",
-			message: `${err.message}: Field ${err.path.join('.')}`,
-			state: { input: tracker },
-		}));
-		return makeLeft(errors);
-	}
+  if (parsed.success) {
+    return makeRight(parsed.data);
+  } else {
+    const errors: RulesError[] = parsed.error.issues.map(err => ({
+      errorType: "INPUT",
+      message: `${err.message}: Field ${err.path.join('.')}`,
+      state: { input: tracker },
+    }));
+    return makeLeft(errors);
+  }
 };
 
 export const callingFunctionValidator = z.object({
-	name: z.string()
-		.trim(),
-	functionSignature: z.string()
-		.trim(),
-	encodedValues: z.string()
-		.trim()
+  name: z.string()
+    .trim(),
+  functionSignature: z.string()
+    .trim(),
+  encodedValues: z.string()
+    .trim()
 });
 
 export interface CallingFunctionJSON extends z.infer<typeof callingFunctionValidator> { }
@@ -241,28 +241,28 @@ export interface CallingFunctionJSON extends z.infer<typeof callingFunctionValid
  * @returns Either the parsed CallingFunctionJSON object or an error.
  */
 export const validateCallingFunctionJSON = (callingFunction: string): Either<RulesError[], CallingFunctionJSON> => {
-	const parsedJson = safeParseJson(callingFunction);
-	if (isLeft(parsedJson)) return parsedJson;
-	const parsed = callingFunctionValidator.safeParse(unwrapEither(parsedJson));
-	if (parsed.success) {
-		return makeRight(parsed.data);
-	} else {
-		const errors: RulesError[] = parsed.error.issues.map(err => ({
-			errorType: "INPUT",
-			message: `${err.message}: Field ${err.path.join('.')}`,
-			state: { input: callingFunction },
-		}));
-		return makeLeft(errors);
-	}
+  const parsedJson = safeParseJson(callingFunction);
+  if (isLeft(parsedJson)) return parsedJson;
+  const parsed = callingFunctionValidator.safeParse(unwrapEither(parsedJson));
+  if (parsed.success) {
+    return makeRight(parsed.data);
+  } else {
+    const errors: RulesError[] = parsed.error.issues.map(err => ({
+      errorType: "INPUT",
+      message: `${err.message}: Field ${err.path.join('.')}`,
+      state: { input: callingFunction },
+    }));
+    return makeLeft(errors);
+  }
 };
 
 export const policyJSONValidator = z.object({
-	Policy: z.string(),
-	PolicyType: z.string(),
-	CallingFunctions: z.array(callingFunctionValidator),
-	ForeignCalls: z.array(foreignCallValidator),
-	Trackers: z.array(trackerValidator),
-	Rules: z.array(ruleValidator),
+  Policy: z.string(),
+  PolicyType: z.string(),
+  CallingFunctions: z.array(callingFunctionValidator),
+  ForeignCalls: z.array(foreignCallValidator),
+  Trackers: z.array(trackerValidator),
+  Rules: z.array(ruleValidator),
 });
 export interface PolicyJSON extends z.infer<typeof policyJSONValidator> { }
 
@@ -273,20 +273,20 @@ export interface PolicyJSON extends z.infer<typeof policyJSONValidator> { }
  * @returns Either the parsed PolicyJSON object or an error.
  */
 export const validatePolicyJSON = (policy: string): Either<RulesError[], PolicyJSON> => {
-	const parsedJson = safeParseJson(policy);
+  const parsedJson = safeParseJson(policy);
 
-	if (isLeft(parsedJson)) return parsedJson;
+  if (isLeft(parsedJson)) return parsedJson;
 
-	const parsed = policyJSONValidator.safeParse(unwrapEither(parsedJson));
+  const parsed = policyJSONValidator.safeParse(unwrapEither(parsedJson));
 
-	if (parsed.success) {
-		return makeRight(parsed.data);
-	} else {
-		const errors: RulesError[] = parsed.error.issues.map(err => ({
-			errorType: "INPUT",
-			message: `${err.message}: Field ${err.path.join('.')}`,
-			state: { input: policy },
-		}));
-		return makeLeft(errors);
-	}
+  if (parsed.success) {
+    return makeRight(parsed.data);
+  } else {
+    const errors: RulesError[] = parsed.error.issues.map(err => ({
+      errorType: "INPUT",
+      message: `${err.message}: Field ${err.path.join('.')}`,
+      state: { input: policy },
+    }));
+    return makeLeft(errors);
+  }
 };

--- a/src/modules/validation.ts
+++ b/src/modules/validation.ts
@@ -11,11 +11,11 @@ import { Address, checksumAddress, isAddress } from "viem";
  * @returns The trimmed input or the original input if not a string.
  */
 const trimPossibleString = (input: any): any => {
-    if (typeof input === "string") {
-        return input.trim()
-    } else {
-        return input
-    }
+	if (typeof input === "string") {
+		return input.trim()
+	} else {
+		return input
+	}
 }
 
 /**
@@ -24,26 +24,26 @@ const trimPossibleString = (input: any): any => {
  * @param input - string to be parsed.
  * @returns Either the parsed string or an error.
  */
-const safeParseJson = (input: string): Either<RulesError[], object> => {
-    try {
-        const result = JSON.parse(input);
-        return makeRight(result);
-    } catch (error) {
-        return makeLeft([{
-            errorType: "INPUT",
-            state: { input },
-            message: "Failed to parse JSON",
-        }]);
-    }
+export const safeParseJson = (input: string): Either<RulesError[], object> => {
+	try {
+		const result = JSON.parse(input);
+		return makeRight(result);
+	} catch (error) {
+		return makeLeft([{
+			errorType: "INPUT",
+			state: { input },
+			message: "Failed to parse JSON",
+		}]);
+	}
 };
 
 export const PType = PT.map((p) => p.name); // ["address", "string", "uint256", "bool", "void", "bytes"]
 
 export const splitFunctionInput = (input: string): string[] => {
-    return input
-        .split("(")[1]
-        .split(")")[0]
-        .split(",");
+	return input
+		.split("(")[1]
+		.split(")")[0]
+		.split(",");
 }
 
 /**
@@ -53,16 +53,16 @@ export const splitFunctionInput = (input: string): string[] => {
  * @returns The errors messages concatenated into a single string
  */
 export const getRulesErrorMessages = (errors: RulesError[]): string => {
-    console.log(errors[0])
-    return errors.map(err => `${err.message}`).join("\n");
+	console.log(errors[0])
+	return errors.map(err => `${err.message}`).join("\n");
 }
 
 
 const ruleValidator = z.object({
-    condition: z.string(),
-    positiveEffects: z.array(z.string()),
-    negativeEffects: z.array(z.string()),
-    callingFunction: z.string(),
+	condition: z.string(),
+	positiveEffects: z.array(z.string()),
+	negativeEffects: z.array(z.string()),
+	callingFunction: z.string(),
 });
 export interface RuleJSON extends z.infer<typeof ruleValidator> { }
 
@@ -73,22 +73,22 @@ export interface RuleJSON extends z.infer<typeof ruleValidator> { }
  * @returns Either the parsed RuleJSON object or an error.
  */
 export const validateRuleJSON = (rule: string): Either<RulesError[], RuleJSON> => {
-    const parsedJson = safeParseJson(rule);
+	const parsedJson = safeParseJson(rule);
 
-    if (isLeft(parsedJson)) return parsedJson;
+	if (isLeft(parsedJson)) return parsedJson;
 
-    const parsed = ruleValidator.safeParse(unwrapEither(parsedJson));
+	const parsed = ruleValidator.safeParse(unwrapEither(parsedJson));
 
-    if (parsed.success) {
-        return makeRight(parsed.data);
-    } else {
-        const errors: RulesError[] = parsed.error.issues.map(err => ({
-            errorType: "INPUT",
-            message: `${err.message}: Field ${err.path.join('.')}`,
-            state: { input: rule },
-        }));
-        return makeLeft(errors);
-    }
+	if (parsed.success) {
+		return makeRight(parsed.data);
+	} else {
+		const errors: RulesError[] = parsed.error.issues.map(err => ({
+			errorType: "INPUT",
+			message: `${err.message}: Field ${err.path.join('.')}`,
+			state: { input: rule },
+		}));
+		return makeLeft(errors);
+	}
 };
 
 /**
@@ -98,32 +98,32 @@ export const validateRuleJSON = (rule: string): Either<RulesError[], RuleJSON> =
  * @returns true if input is valid, false if input is invalid.
  */
 export const validateFCFunctionInput = (input: string): boolean => {
-    const parameterSplit = splitFunctionInput(input);
+	const parameterSplit = splitFunctionInput(input);
 
-    return parameterSplit.filter(
-        (parameter) => !PType.includes(parameter.trim())
-    ).length === 0;
+	return parameterSplit.filter(
+		(parameter) => !PType.includes(parameter.trim())
+	).length === 0;
 }
 
 export const foreignCallValidator = z.object({
-    name: z.string(),
-    function: z.string()
-        .trim()
-        .refine(
-            validateFCFunctionInput,
-            { message: "Unsupported argument type" }
-        ),
-    address: z.string()
-        .trim()
-        .refine((input) => isAddress(input), {
-            message: `Address is invalid`,
-        })
-        .transform((input) => checksumAddress(input.trim() as Address)),
-    returnType: z.preprocess(trimPossibleString, z.literal(PType, "Unsupported return type")),
-    valuesToPass: z.string()
-        .trim(),
-    callingFunction: z.string()
-        .trim()
+	name: z.string(),
+	function: z.string()
+		.trim()
+		.refine(
+			validateFCFunctionInput,
+			{ message: "Unsupported argument type" }
+		),
+	address: z.string()
+		.trim()
+		.refine((input) => isAddress(input), {
+			message: `Address is invalid`,
+		})
+		.transform((input) => checksumAddress(input.trim() as Address)),
+	returnType: z.preprocess(trimPossibleString, z.literal(PType, "Unsupported return type")),
+	valuesToPass: z.string()
+		.trim(),
+	callingFunction: z.string()
+		.trim()
 
 });
 
@@ -136,30 +136,30 @@ export interface ForeignCallJSON extends z.infer<typeof foreignCallValidator> { 
  * @returns Either the parsed ForeignCallJSON object or an error.
  */
 export const validateForeignCallJSON = (foreignCall: string): Either<RulesError[], ForeignCallJSON> => {
-    const parsedJson = safeParseJson(foreignCall);
+	const parsedJson = safeParseJson(foreignCall);
 
-    if (isLeft(parsedJson)) return parsedJson;
+	if (isLeft(parsedJson)) return parsedJson;
 
-    const parsed = foreignCallValidator.safeParse(unwrapEither(parsedJson));
+	const parsed = foreignCallValidator.safeParse(unwrapEither(parsedJson));
 
-    if (parsed.success) {
-        return makeRight(parsed.data);
-    } else {
-        const errors: RulesError[] = parsed.error.issues.map(err => ({
-            errorType: "INPUT",
-            message: `${err.message}: Field ${err.path.join('.')}`,
-            state: { input: foreignCall },
-        }));
-        return makeLeft(errors);
-    }
+	if (parsed.success) {
+		return makeRight(parsed.data);
+	} else {
+		const errors: RulesError[] = parsed.error.issues.map(err => ({
+			errorType: "INPUT",
+			message: `${err.message}: Field ${err.path.join('.')}`,
+			state: { input: foreignCall },
+		}));
+		return makeLeft(errors);
+	}
 };
 
 export const supportedTrackerTypes: string[] = [
-    "uint256",
-    "string",
-    "address",
-    "bytes",
-    "bool",
+	"uint256",
+	"string",
+	"address",
+	"bytes",
+	"bool",
 ];
 
 /**
@@ -169,31 +169,31 @@ export const supportedTrackerTypes: string[] = [
  * @returns true if input is valid, false if input is invalid.
  */
 const validateTrackerValue = (data: any) => {
-    // Validate that the initialValue matches the type
-    switch (data.type) {
-        case "uint256":
-            return !isNaN(Number(data.initialValue));
-        case "string":
-            return typeof data.initialValue === "string";
-        case "address":
-            return isAddress(data.initialValue);
-        case "bytes":
-            return typeof data.initialValue === "string"; // Assuming bytes are represented as hex strings
-        case "bool":
-            return true;
-        default:
-            return false; // Should never happen due to z.literal
-    }
+	// Validate that the initialValue matches the type
+	switch (data.type) {
+		case "uint256":
+			return !isNaN(Number(data.initialValue));
+		case "string":
+			return typeof data.initialValue === "string";
+		case "address":
+			return isAddress(data.initialValue);
+		case "bytes":
+			return typeof data.initialValue === "string"; // Assuming bytes are represented as hex strings
+		case "bool":
+			return true;
+		default:
+			return false; // Should never happen due to z.literal
+	}
 }
 
 export const trackerValidator = z.object({
-    name: z.string()
-        .trim(),
-    type: z.preprocess(trimPossibleString, z.literal(supportedTrackerTypes, "Unsupported type")),
-    initialValue: z.string()
-        .trim()
+	name: z.string()
+		.trim(),
+	type: z.preprocess(trimPossibleString, z.literal(supportedTrackerTypes, "Unsupported type")),
+	initialValue: z.string()
+		.trim()
 }).refine(validateTrackerValue, {
-    message: "Initial Value doesn't match type",
+	message: "Initial Value doesn't match type",
 });
 
 export interface TrackerJSON extends z.infer<typeof trackerValidator> { }
@@ -205,31 +205,31 @@ export interface TrackerJSON extends z.infer<typeof trackerValidator> { }
  * @returns Either the parsed TrackerJSON object or an error.
  */
 export const validateTrackerJSON = (tracker: string): Either<RulesError[], TrackerJSON> => {
-    const parsedJson = safeParseJson(tracker);
+	const parsedJson = safeParseJson(tracker);
 
-    if (isLeft(parsedJson)) return parsedJson;
+	if (isLeft(parsedJson)) return parsedJson;
 
-    const parsed = trackerValidator.safeParse(unwrapEither(parsedJson));
+	const parsed = trackerValidator.safeParse(unwrapEither(parsedJson));
 
-    if (parsed.success) {
-        return makeRight(parsed.data);
-    } else {
-        const errors: RulesError[] = parsed.error.issues.map(err => ({
-            errorType: "INPUT",
-            message: `${err.message}: Field ${err.path.join('.')}`,
-            state: { input: tracker },
-        }));
-        return makeLeft(errors);
-    }
+	if (parsed.success) {
+		return makeRight(parsed.data);
+	} else {
+		const errors: RulesError[] = parsed.error.issues.map(err => ({
+			errorType: "INPUT",
+			message: `${err.message}: Field ${err.path.join('.')}`,
+			state: { input: tracker },
+		}));
+		return makeLeft(errors);
+	}
 };
 
 export const callingFunctionValidator = z.object({
-    name: z.string()
-        .trim(),
-    functionSignature: z.string()
-        .trim(),
-    encodedValues: z.string()
-        .trim()
+	name: z.string()
+		.trim(),
+	functionSignature: z.string()
+		.trim(),
+	encodedValues: z.string()
+		.trim()
 });
 
 export interface CallingFunctionJSON extends z.infer<typeof callingFunctionValidator> { }
@@ -241,28 +241,28 @@ export interface CallingFunctionJSON extends z.infer<typeof callingFunctionValid
  * @returns Either the parsed CallingFunctionJSON object or an error.
  */
 export const validateCallingFunctionJSON = (callingFunction: string): Either<RulesError[], CallingFunctionJSON> => {
-    const parsedJson = safeParseJson(callingFunction);
-    if (isLeft(parsedJson)) return parsedJson;
-    const parsed = callingFunctionValidator.safeParse(unwrapEither(parsedJson));
-    if (parsed.success) {
-        return makeRight(parsed.data);
-    } else {
-        const errors: RulesError[] = parsed.error.issues.map(err => ({
-            errorType: "INPUT",
-            message: `${err.message}: Field ${err.path.join('.')}`,
-            state: { input: callingFunction },
-        }));
-        return makeLeft(errors);
-    }
+	const parsedJson = safeParseJson(callingFunction);
+	if (isLeft(parsedJson)) return parsedJson;
+	const parsed = callingFunctionValidator.safeParse(unwrapEither(parsedJson));
+	if (parsed.success) {
+		return makeRight(parsed.data);
+	} else {
+		const errors: RulesError[] = parsed.error.issues.map(err => ({
+			errorType: "INPUT",
+			message: `${err.message}: Field ${err.path.join('.')}`,
+			state: { input: callingFunction },
+		}));
+		return makeLeft(errors);
+	}
 };
 
 export const policyJSONValidator = z.object({
-    Policy: z.string(),
-    PolicyType: z.string(),
-    CallingFunctions: z.array(callingFunctionValidator),
-    ForeignCalls: z.array(foreignCallValidator),
-    Trackers: z.array(trackerValidator),
-    Rules: z.array(ruleValidator),
+	Policy: z.string(),
+	PolicyType: z.string(),
+	CallingFunctions: z.array(callingFunctionValidator),
+	ForeignCalls: z.array(foreignCallValidator),
+	Trackers: z.array(trackerValidator),
+	Rules: z.array(ruleValidator),
 });
 export interface PolicyJSON extends z.infer<typeof policyJSONValidator> { }
 
@@ -273,20 +273,20 @@ export interface PolicyJSON extends z.infer<typeof policyJSONValidator> { }
  * @returns Either the parsed PolicyJSON object or an error.
  */
 export const validatePolicyJSON = (policy: string): Either<RulesError[], PolicyJSON> => {
-    const parsedJson = safeParseJson(policy);
+	const parsedJson = safeParseJson(policy);
 
-    if (isLeft(parsedJson)) return parsedJson;
+	if (isLeft(parsedJson)) return parsedJson;
 
-    const parsed = policyJSONValidator.safeParse(unwrapEither(parsedJson));
+	const parsed = policyJSONValidator.safeParse(unwrapEither(parsedJson));
 
-    if (parsed.success) {
-        return makeRight(parsed.data);
-    } else {
-        const errors: RulesError[] = parsed.error.issues.map(err => ({
-            errorType: "INPUT",
-            message: `${err.message}: Field ${err.path.join('.')}`,
-            state: { input: policy },
-        }));
-        return makeLeft(errors);
-    }
+	if (parsed.success) {
+		return makeRight(parsed.data);
+	} else {
+		const errors: RulesError[] = parsed.error.issues.map(err => ({
+			errorType: "INPUT",
+			message: `${err.message}: Field ${err.path.join('.')}`,
+			state: { input: policy },
+		}));
+		return makeLeft(errors);
+	}
 };

--- a/src/parsing/parser.ts
+++ b/src/parsing/parser.ts
@@ -8,7 +8,6 @@ import {
   getAddress,
 } from "viem";
 import {
-  callingFunctionJSON,
   FCNameToID,
   ForeignCallDefinition,
   ForeignCallEncodedIndex,
@@ -33,7 +32,7 @@ import {
   cleanseForeignCallLists
 } from './parsing-utilities';
 
-import { ForeignCallJSON, PType, RuleJSON, splitFunctionInput, TrackerJSON } from "../modules/validation";
+import { CallingFunctionJSON, ForeignCallJSON, PType, RuleJSON, splitFunctionInput, TrackerJSON } from "../modules/validation";
 
 /**
  * @file parser.ts
@@ -252,35 +251,31 @@ export function parseForeignCallDefinition(
 ): ForeignCallDefinition {
 
   var encodedIndices: ForeignCallEncodedIndex[] = syntax.valuesToPass.split(",")
-    .map((encodedIndex: string, iter: number) => {
+    .map((encodedIndex: string) => {
 
       if (encodedIndex.includes("FC:")) {
         for (var fcMap of foreignCallNameToID) {
           if ("FC:" + fcMap.name.trim() == encodedIndex.trim()) {
-            var val: ForeignCallEncodedIndex = { eType: 1, index: fcMap.id };
-            encodedIndices.push(val);
+            return { eType: 1, index: fcMap.id };
           }
         }
       } else if (encodedIndex.includes("TR:")) {
         for (var trMap of indexMap) {
           if ("TR:" + trMap.name.trim() == encodedIndex.trim()) {
-            var val: ForeignCallEncodedIndex = { eType: 2, index: trMap.id };
-            encodedIndices.push(val);
+            return { eType: 2, index: trMap.id };
           }
         }
       } else {
         var iter = 0;
         for (var functionArg of functionArguments) {
           if (functionArg.trim() == encodedIndex.trim()) {
-            var val: ForeignCallEncodedIndex = { eType: 0, index: iter };
-            encodedIndices.push(val);
-            break;
+            return { eType: 0, index: iter };
           } else {
             iter += 1;
           }
         }
       }
-    });
+    }) as ForeignCallEncodedIndex[];
 
   const returnType: number = PType.indexOf(syntax.returnType);
 
@@ -301,7 +296,7 @@ export function parseForeignCallDefinition(
   };
 }
 
-export function parseCallingFunction(syntax: callingFunctionJSON): string[] {
+export function parseCallingFunction(syntax: CallingFunctionJSON): string[] {
   var initialSplit = syntax.encodedValues.split(", ");
   var variableNames: string[] = [];
   for (var ind of initialSplit) {

--- a/src/parsing/parser.ts
+++ b/src/parsing/parser.ts
@@ -8,6 +8,7 @@ import {
   getAddress,
 } from "viem";
 import {
+  callingFunctionJSON,
   FCNameToID,
   ForeignCallDefinition,
   ForeignCallEncodedIndex,

--- a/src/parsing/parser.ts
+++ b/src/parsing/parser.ts
@@ -1,32 +1,24 @@
 /// SPDX-License-Identifier: BUSL-1.1
 import {
   encodePacked,
-  Address,
   toHex,
   encodeAbiParameters,
   parseAbiParameters,
   stringToBytes,
+  getAddress,
 } from "viem";
 import {
-  callingFunctionJSON,
-  Either,
   FCNameToID,
   ForeignCallDefinition,
   ForeignCallEncodedIndex,
-  foreignCallJSON,
   matchArray,
   operandArray,
-  PlaceholderStruct,
   PT,
-  pTypeEnum,
   RuleComponent,
   RuleDefinition,
-  ruleJSON,
-  RulesError,
-  supportedTrackerTypes,
   TrackerDefinition,
   trackerIndexNameMapping,
-  trackerJSON,
+
 } from "../modules/types";
 import { convertHumanReadableToInstructionSet } from "./internal-parsing-logic";
 import {
@@ -37,15 +29,10 @@ import {
   parseForeignCalls,
   buildPlaceholderList,
   parseEffect,
-  cleanseForeignCallLists,
-} from "./parsing-utilities";
-import {
-  getAddress,
-  isLeft,
-  makeLeft,
-  makeRight,
-  unwrapEither,
-} from "../modules/utils";
+  cleanseForeignCallLists
+} from './parsing-utilities';
+
+import { ForeignCallJSON, PType, RuleJSON, splitFunctionInput, TrackerJSON } from "../modules/validation";
 
 /**
  * @file parser.ts
@@ -78,7 +65,7 @@ import {
  */
 
 export function parseRuleSyntax(
-  syntax: ruleJSON,
+  syntax: RuleJSON,
   indexMap: trackerIndexNameMapping[],
   foreignCallNameToID: FCNameToID[],
   encodedValues: string,
@@ -207,48 +194,25 @@ export function parseRuleSyntax(
  * @param syntax - The JSON representation of the tracker syntax.
  * @returns Either an object containing the tracker's name, type, and encoded default value if successful or an error
  */
-export function parseTrackerSyntax(
-  syntax: trackerJSON
-): Either<RulesError, TrackerDefinition> {
-  let trackerType = syntax.type.trim();
-  if (!supportedTrackerTypes.includes(trackerType)) {
-    return makeLeft({
-      errorType: "INPUT",
-      state: { supportedTrackerTypes, trackerType },
-      message: "Unsupported type",
-    });
-  }
+export function parseTrackerSyntax(syntax: TrackerJSON): TrackerDefinition {
+  let trackerType = syntax.type;
+
   var trackerInitialValue: any;
   if (trackerType == "uint256") {
-    if (!isNaN(Number(syntax.initialValue))) {
-      trackerInitialValue = encodePacked(
-        ["uint256"],
-        [BigInt(syntax.initialValue)]
-      );
-    } else {
-      return makeLeft({
-        errorType: "INPUT",
-        state: { defaultValue: syntax.initialValue },
-        message: "Default Value doesn't match type",
-      });
-    }
+    trackerInitialValue = encodePacked(
+      ["uint256"],
+      [BigInt(syntax.initialValue)]
+    );
   } else if (trackerType == "address") {
-    const validatedAddress = getAddress(syntax.initialValue.trim());
-    if (isLeft(validatedAddress)) {
-      return validatedAddress;
-    } else {
-      var address = encodeAbiParameters(parseAbiParameters("address"), [
-        unwrapEither(validatedAddress),
-      ]);
-
-      trackerInitialValue = address;
-    }
+    const validatedAddress = getAddress(syntax.initialValue);
+    trackerInitialValue = encodeAbiParameters(
+      parseAbiParameters('address'),
+      [validatedAddress]
+    )
   } else if (trackerType == "bytes") {
-    var bytes = encodeAbiParameters(parseAbiParameters("bytes"), [
-      toHex(stringToBytes(String(syntax.initialValue.trim()))),
+    trackerInitialValue = encodeAbiParameters(parseAbiParameters("bytes"), [
+      toHex(stringToBytes(String(syntax.initialValue))),
     ]);
-
-    trackerInitialValue = bytes;
   } else if (trackerType == "bool") {
     if (syntax.initialValue == "true") {
       trackerInitialValue = encodePacked(["uint256"], [1n]);
@@ -257,7 +221,7 @@ export function parseTrackerSyntax(
     }
   } else {
     trackerInitialValue = encodeAbiParameters(parseAbiParameters("string"), [
-      syntax.initialValue.trim(),
+      syntax.initialValue,
     ]);
   }
   var trackerTypeEnum = 0;
@@ -266,11 +230,11 @@ export function parseTrackerSyntax(
       trackerTypeEnum = parameterType.enumeration;
     }
   }
-  return makeRight({
-    name: syntax.name.trim(),
+  return {
+    name: syntax.name,
     type: trackerTypeEnum,
     initialValue: trackerInitialValue,
-  });
+  };
 }
 
 /**
@@ -280,54 +244,15 @@ export function parseTrackerSyntax(
  * @returns Either an object containing the foreign call's name, address, function, return type, parameter types, and encoded indices if successful or an error.
  */
 export function parseForeignCallDefinition(
-  syntax: foreignCallJSON,
+  syntax: ForeignCallJSON,
   foreignCallNameToID: FCNameToID[],
   indexMap: FCNameToID[],
   functionArguments: string[]
-): Either<RulesError, ForeignCallDefinition> {
-  const validatedAddress = getAddress(syntax.address.trim());
-  if (isLeft(validatedAddress)) {
-    return validatedAddress;
-  } else {
-    const address = unwrapEither(validatedAddress);
-    var func = syntax.function.trim();
-    var returnType = pTypeEnum.VOID; // default to void
-    if (!PT.some((parameter) => parameter.name === syntax.returnType)) {
-      return makeLeft({
-        errorType: "INPUT",
-        state: { PT, syntax },
-        message: "Unsupported return type",
-      });
-    }
-    for (var parameterType of PT) {
-      if (parameterType.name == syntax.returnType) {
-        returnType = parameterType.enumeration;
-      }
-    }
-    var parameterTypes: number[] = [];
-    var parameterSplit = syntax.function
-      .trim()
-      .split("(")[1]
-      .split(")")[0]
-      .split(",");
-    for (var fcParameter of parameterSplit) {
-      if (!PT.some((parameter) => parameter.name === fcParameter.trim())) {
-        return makeLeft({
-          errorType: "INPUT",
-          state: { PT, syntax },
-          message: "Unsupported argument type",
-        });
-      }
-      for (var parameterType of PT) {
-        if (fcParameter.trim() == parameterType.name) {
-          parameterTypes.push(parameterType.enumeration);
-        }
-      }
-    }
+): ForeignCallDefinition {
 
-    var encodedIndices: ForeignCallEncodedIndex[] = [];
-    var encodedIndecesSplit = syntax.valuesToPass.trim().split(",");
-    for (var encodedIndex of encodedIndecesSplit) {
+  var encodedIndices: ForeignCallEncodedIndex[] = syntax.valuesToPass.split(",")
+    .map((encodedIndex: string, iter: number) => {
+
       if (encodedIndex.includes("FC:")) {
         for (var fcMap of foreignCallNameToID) {
           if ("FC:" + fcMap.name.trim() == encodedIndex.trim()) {
@@ -354,17 +279,25 @@ export function parseForeignCallDefinition(
           }
         }
       }
-    }
-
-    return makeRight({
-      name: syntax.name.trim(),
-      address: address,
-      function: func,
-      returnType: returnType,
-      parameterTypes: parameterTypes,
-      encodedIndices: encodedIndices,
     });
-  }
+
+  const returnType: number = PType.indexOf(syntax.returnType);
+
+  const parameterTypes: number[] = splitFunctionInput(syntax.function)
+    .map((param) => PType.indexOf(param));
+
+  var valuesToPass: number[] = syntax.valuesToPass.split(",")
+    .filter((input: string) => !isNaN(Number(input)))
+    .map((input: string) => Number(input));
+
+
+
+  return {
+    ...syntax,
+    returnType,
+    parameterTypes,
+    encodedIndices,
+  };
 }
 
 export function parseCallingFunction(syntax: callingFunctionJSON): string[] {

--- a/src/parsing/reverse-parsing-logic.ts
+++ b/src/parsing/reverse-parsing-logic.ts
@@ -3,12 +3,12 @@
 import {
   stringReplacement,
   RuleStruct,
-  ruleJSON,
   PT,
   ForeignCallOnChain,
   TrackerOnChain,
   hexToFunctionString,
 } from "../modules/types";
+import { RuleJSON } from "../modules/validation";
 import { parseFunctionArguments } from "./parsing-utilities";
 
 /**
@@ -352,8 +352,8 @@ export function convertRuleStructToString(
   foreignCalls: ForeignCallOnChain[],
   trackers: TrackerOnChain[],
   mappings: hexToFunctionString[]
-): ruleJSON {
-  var rJSON: ruleJSON = {
+): RuleJSON {
+  var rJSON: RuleJSON = {
     condition: "",
     positiveEffects: [],
     negativeEffects: [],

--- a/tests/code-generation.test.ts
+++ b/tests/code-generation.test.ts
@@ -30,7 +30,7 @@ test("Code Generation test)", () => {
         {
             "name": "Simple String Tracker",
             "type": "string",
-            "defaultValue": "test" 
+            "initialValue": "test" 
         }
         ],
         "Rules": [

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -914,7 +914,24 @@ test("Creates a simple foreign call", () => {
   "valuesToPass": "to, FC:testSigTwo, TR:thisTracker"
   }`;
 
-  var retVal = parseForeignCallDefinition(JSON.parse(str))
+  var retVal = parseForeignCallDefinition(
+    JSON.parse(str),
+    [
+      {
+        id: 1,
+        name: "testSigTwo",
+        type: 1,
+      },
+    ],
+    [
+      {
+        id: 1,
+        name: "thisTracker",
+        type: 1,
+      },
+    ],
+    ["to", "someString", "value"]
+  )
   expect(retVal.name).toEqual("Simple Foreign Call");
   expect(retVal.address).toEqual(
     getAddress("0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC")
@@ -2353,7 +2370,12 @@ test("Creates a simple foreign call with a boolean return", () => {
   "callingFunction": "someFunction(address to, string someString, uint256 value)"
   }`;
 
-  var retVal = parseForeignCallDefinition(JSON.parse(str))
+  var retVal = parseForeignCallDefinition(
+    JSON.parse(str),
+    [],
+    [],
+    ["to", "someString", "value"]
+  );
   expect(retVal.name).toEqual("Simple Foreign Call");
   expect(retVal.address).toEqual(
     getAddress("0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC")

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -799,10 +799,8 @@ test("Creates a simple uint256 tracker", () => {
         "name": "Simple Int Tracker",
         "type": "uint256",
         "initialValue": "14"
-        }`;
-  var retVal = unwrapEither(
-    parseTrackerSyntax(JSON.parse(str))
-  ) as TrackerDefinition;
+        }`
+  var retVal = parseTrackerSyntax(JSON.parse(str))
 
   expect(retVal.name).toEqual("Simple Int Tracker");
   expect(retVal.type).toEqual(pTypeEnum.UINT256);
@@ -816,15 +814,12 @@ test("Creates a simple bool tracker", () => {
         "name": "Simple bool Tracker",
         "type": "bool",
         "initialValue": "true"
-        }`;
-  var retVal = unwrapEither(
-    parseTrackerSyntax(JSON.parse(str))
-  ) as TrackerDefinition;
-  expect(retVal.name).toEqual("Simple bool Tracker");
-  expect(retVal.type).toEqual(pTypeEnum.BOOL);
-  expect(retVal.initialValue).toEqual(
-    encodeAbiParameters(parseAbiParameters("uint256"), [BigInt(1)])
-  );
+        }`
+  var retVal = parseTrackerSyntax(JSON.parse(str))
+  expect(retVal.name).toEqual("Simple bool Tracker")
+  expect(retVal.type).toEqual(pTypeEnum.BOOL)
+  expect(retVal.initialValue).toEqual(encodeAbiParameters(
+    parseAbiParameters('uint256'), [BigInt(1)]))
 });
 
 test('Reverse Interpretation for the: "Evaluates a simple syntax string (using AND + OR operators and function parameters)" test', () => {
@@ -889,17 +884,12 @@ test("Creates a simple address tracker", () => {
   "name": "Simple Address Tracker",
   "type": "address",
   "initialValue": "0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC"
-  }`;
-  var retVal = unwrapEither(
-    parseTrackerSyntax(JSON.parse(str))
-  ) as TrackerDefinition;
-  expect(retVal.name).toEqual("Simple Address Tracker");
-  expect(retVal.type).toEqual(pTypeEnum.ADDRESS);
-  expect(retVal.initialValue).toEqual(
-    encodeAbiParameters(parseAbiParameters("address"), [
-      "0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC",
-    ])
-  );
+  }`
+  var retVal = parseTrackerSyntax(JSON.parse(str))
+  expect(retVal.name).toEqual("Simple Address Tracker")
+  expect(retVal.type).toEqual(pTypeEnum.ADDRESS)
+  expect(retVal.initialValue).toEqual(encodeAbiParameters(
+    parseAbiParameters('address'), ['0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC']))
 });
 
 test("Creates a simple string tracker", () => {
@@ -907,25 +897,12 @@ test("Creates a simple string tracker", () => {
   "name": "Simple String Tracker",
   "type": "string",
   "initialValue": "test"
-  }`;
-  var retVal = unwrapEither(
-    parseTrackerSyntax(JSON.parse(str))
-  ) as TrackerDefinition;
-  expect(retVal.name).toEqual("Simple String Tracker");
-  expect(retVal.type).toEqual(pTypeEnum.STRING);
-  expect(retVal.initialValue).toEqual(
-    encodeAbiParameters(parseAbiParameters("string"), ["test"])
-  );
-});
-
-test("Tests unsupported type", () => {
-  var str = `{
-  "name": "Simple String Tracker",
-  "type": "book",
-  "initialValue": "test"
-  }`;
-  var retVal = unwrapEither(parseTrackerSyntax(JSON.parse(str))) as RulesError;
-  expect(retVal.message).toEqual("Unsupported type");
+  }`
+  var retVal = parseTrackerSyntax(JSON.parse(str))
+  expect(retVal.name).toEqual("Simple String Tracker")
+  expect(retVal.type).toEqual(pTypeEnum.STRING)
+  expect(retVal.initialValue).toEqual(encodeAbiParameters(
+    parseAbiParameters('string'), ['test']))
 });
 
 test("Creates a simple foreign call", () => {
@@ -937,26 +914,7 @@ test("Creates a simple foreign call", () => {
   "valuesToPass": "to, FC:testSigTwo, TR:thisTracker"
   }`;
 
-  var retVal = unwrapEither(
-    parseForeignCallDefinition(
-      JSON.parse(str),
-      [
-        {
-          id: 1,
-          name: "testSigTwo",
-          type: 1,
-        },
-      ],
-      [
-        {
-          id: 1,
-          name: "thisTracker",
-          type: 1,
-        },
-      ],
-      ["to", "someString", "value"]
-    )
-  ) as ForeignCallDefinition;
+  var retVal = parseForeignCallDefinition(JSON.parse(str))
   expect(retVal.name).toEqual("Simple Foreign Call");
   expect(retVal.address).toEqual(
     getAddress("0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC")
@@ -965,65 +923,6 @@ test("Creates a simple foreign call", () => {
   expect(retVal.returnType).toEqual(2);
   console.log(retVal.encodedIndices);
   expect(retVal.encodedIndices[1].eType).toEqual(1);
-});
-
-test("Tests incorrect format for address", () => {
-  var str = `{
-  "name": "Simple Foreign Call",
-  "address": "test",
-  "function": "testSig(address,string,uint256)",
-  "returnType": "uint256",
-  "valuesToPass": "to, someString, value"
-  }`;
-
-  var retVal = unwrapEither(
-    parseForeignCallDefinition(
-      JSON.parse(str),
-      [],
-      [],
-      ["to", "someString", "value"]
-    )
-  ) as RulesError;
-  expect(retVal.message).toEqual('Address "test" is invalid');
-});
-
-test("Tests unsupported return type", () => {
-  var str = `{
-  "name": "Simple Foreign Call",
-  "address": "0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC",
-  "function": "testSig(address,string,uint256)",
-  "returnType": "notAnInt",
-  "valuesToPass": "to, someString, value"
-  }`;
-  var retVal = unwrapEither(
-    parseForeignCallDefinition(
-      JSON.parse(str),
-      [],
-      [],
-      ["to", "someString", "value"]
-    )
-  ) as RulesError;
-  expect(retVal.message).toEqual("Unsupported return type");
-});
-
-test("Tests unsupported argument type", () => {
-  var str = `{
-    "name": "Simple Foreign Call",
-    "address": "0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC",
-    "function": "testSig(address,notAnInt,uint256)",
-    "returnType": "uint256",
-    "valuesToPass": "to, value, otherValue"
-    }`;
-
-  var retVal = unwrapEither(
-    parseForeignCallDefinition(
-      JSON.parse(str),
-      [],
-      [],
-      ["to", "value", "otherValue"]
-    )
-  ) as RulesError;
-  expect(retVal.message).toEqual("Unsupported argument type");
 });
 
 test("Evaluates a simple syntax string with a Foreign Call", () => {
@@ -2454,14 +2353,7 @@ test("Creates a simple foreign call with a boolean return", () => {
   "callingFunction": "someFunction(address to, string someString, uint256 value)"
   }`;
 
-  var retVal = unwrapEither(
-    parseForeignCallDefinition(
-      JSON.parse(str),
-      [],
-      [],
-      ["to", "someString", "value"]
-    )
-  ) as ForeignCallDefinition;
+  var retVal = parseForeignCallDefinition(JSON.parse(str))
   expect(retVal.name).toEqual("Simple Foreign Call");
   expect(retVal.address).toEqual(
     getAddress("0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC")

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -1,7 +1,8 @@
 import { expect, test } from "vitest";
-import { validateRuleJSON, validateForeignCallJSON, validateTrackerJSON, validatePolicyJSON } from "../src/modules/validation";
+import { validateRuleJSON, validateForeignCallJSON, validateTrackerJSON, validatePolicyJSON, safeParseJson } from "../src/modules/validation";
 import { isLeft, isRight, unwrapEither } from "../src/modules/utils";
 import { RulesError } from "../src/modules/types";
+import { safeParse } from "zod/v4/core";
 
 const ruleJSON = `{
 				"condition": "3 + 4 > 5 AND (1 == 1 AND 2 == 2)",
@@ -408,6 +409,30 @@ test("Tests unsupported type", () => {
 				}`;
 	var retVal = unwrapEither(validateTrackerJSON(str)) as RulesError[]
 	expect(retVal[0].message).toEqual('Unsupported type: Field type');
+});
+
+test("Tests can safely parse json", () => {
+	const str = `{
+				"type": 1,
+				"name": "foo"
+				}`;
+	const retVal = safeParseJson(str);
+	expect(isRight(retVal)).toBeTruthy();
+	const parsed = unwrapEither(retVal) as any;
+	expect(parsed.type).toEqual(1);
+	expect(parsed.name).toEqual("foo");
+});
+
+test("Tests can return error when parsing invalid json", () => {
+	const str = `{
+				"type": 1,
+				"name": "foo",
+				}`;
+	const retVal = safeParseJson(str);
+	expect(isLeft(retVal)).toBeTruthy();
+	const parsed = unwrapEither(retVal) as RulesError[];
+	expect(parsed[0].message).toEqual("Failed to parse JSON");
+
 });
 
 

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -1,40 +1,402 @@
 import { expect, test } from "vitest";
-import { validateRuleJSON } from "../src/modules/validation";
+import { validateRuleJSON, validateForeignCallJSON, validateTrackerJSON, validatePolicyJSON } from "../src/modules/validation";
 import { isLeft, isRight, unwrapEither } from "../src/modules/utils";
+import { RulesError } from "../src/modules/types";
 
-test("Can return error if rule JSON is invalid", () => {
-  var ruleStringA = `{
+const ruleJSON = `{
+        "condition": "3 + 4 > 5 AND (1 == 1 AND 2 == 2)",
         "positiveEffects": ["revert"],
         "negativeEffects": [],
         "callingFunction": "addValue(uint256 value)",
         "encodedValues": "uint256 value"
         }`;
-  const parsedRule = validateRuleJSON(ruleStringA);
-  expect(isLeft(parsedRule)).toBeTruthy();
-  if (isLeft(parsedRule)) {
-    const errors = unwrapEither(parsedRule);
-    expect(errors.length).toEqual(1);
-    expect(errors[0].message).toEqual(
-      "Error: Invalid input: expected string, received undefined: Field condition"
-    );
-  }
+
+const fcJSON = `{
+          "name": "Simple Foreign Call",
+          "address": "0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC",
+          "function": "testSig(address,string,uint256)",
+          "returnType": "uint256",
+          "valuesToPass": "0, 1, 2"
+          }`;
+
+const trackerJSON = `{
+              "name": "Simple String Tracker",
+              "type": "uint256",
+              "initialValue": "4"
+          }`;
+
+const policyJSON = `
+    {
+    "Policy": "Test Policy",
+    "PolicyType": "open",
+    "ForeignCalls": [
+        {
+            "name": "Simple Foreign Call",
+            "address": "0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC",
+            "function": "testSig(address)",
+            "returnType": "uint256",
+            "valuesToPass": "0"
+        }
+    ],
+    "Trackers": [
+    {
+        "name": "Simple String Tracker",
+        "type": "string",
+        "initialValue": "test"
+    }
+    ],
+    "Rules": [
+        {
+            "condition": "value > 500",
+            "positiveEffects": ["emit Success"],
+            "negativeEffects": ["revert()"],
+            "callingFunction": "transfer(address to, uint256 value)",
+            "encodedValues": "address to, uint256 value"
+        }
+        ]
+    }`;
+
+test("Can validate rule JSON", () => {
+    const parsedRule = validateRuleJSON(ruleJSON)
+    expect(isRight(parsedRule)).toBeTruthy();
+    if (isRight(parsedRule)) {
+        const rule = unwrapEither(parsedRule);
+
+        expect(rule.encodedValues).toEqual(JSON.parse(ruleJSON).encodedValues);
+    }
+});
+
+test("Can catch all missing required fields in rule JSON", () => {
+    const parsedRule = validateRuleJSON("{}")
+    expect(isLeft(parsedRule)).toBeTruthy();
+    if (isLeft(parsedRule)) {
+        const errors = unwrapEither(parsedRule);
+
+        expect(errors.length).toEqual(5);
+        expect(errors[0].message).toEqual("Invalid input: expected string, received undefined: Field condition");
+        expect(errors[1].message).toEqual("Invalid input: expected array, received undefined: Field positiveEffects");
+        expect(errors[2].message).toEqual("Invalid input: expected array, received undefined: Field negativeEffects");
+        expect(errors[3].message).toEqual("Invalid input: expected string, received undefined: Field callingFunction");
+        expect(errors[4].message).toEqual("Invalid input: expected string, received undefined: Field encodedValues");
+    }
+});
+
+test("Can catch all wrong input types for fields in rule JSON", () => {
+    const invalidJSON = `{
+        "condition": 1,
+        "positiveEffects": "foo",
+        "negativeEffects": "bar",
+        "callingFunction": 1,
+        "encodedValues": 1
+        }`;
+    const parsedRule = validateRuleJSON(invalidJSON);
+    expect(isLeft(parsedRule)).toBeTruthy();
+    if (isLeft(parsedRule)) {
+        const errors = unwrapEither(parsedRule);
+
+        expect(errors.length).toEqual(5);
+        expect(errors[0].message).toEqual("Invalid input: expected string, received number: Field condition");
+        expect(errors[1].message).toEqual("Invalid input: expected array, received string: Field positiveEffects");
+        expect(errors[2].message).toEqual("Invalid input: expected array, received string: Field negativeEffects");
+        expect(errors[3].message).toEqual("Invalid input: expected string, received number: Field callingFunction");
+        expect(errors[4].message).toEqual("Invalid input: expected string, received number: Field encodedValues");
+    }
+});
+
+test("Can return error if rule JSON is invalid", () => {
+
+    let invalidRuleJSON = JSON.parse(ruleJSON);
+    delete invalidRuleJSON.condition; // Remove condition to make it invalid
+    const parsedRule = validateRuleJSON(JSON.stringify(invalidRuleJSON))
+    expect(isLeft(parsedRule)).toBeTruthy();
+    if (isLeft(parsedRule)) {
+        const errors = unwrapEither(parsedRule);
+        expect(errors.length).toEqual(1);
+        expect(errors[0].message).toEqual("Invalid input: expected string, received undefined: Field condition");
+    }
 });
 
 test("Can return multiple errors if rule JSON is invalid", () => {
-  var ruleStringA = `{
-        "positiveEffects": ["revert"],
-        "negativeEffects": []
-        }`;
-  const parsedRule = validateRuleJSON(ruleStringA);
-  expect(isLeft(parsedRule)).toBeTruthy();
-  if (isLeft(parsedRule)) {
-    const errors = unwrapEither(parsedRule);
-    expect(errors.length).toEqual(2);
-    expect(errors[0].message).toEqual(
-      "Error: Invalid input: expected string, received undefined: Field condition"
-    );
-    expect(errors[1].message).toEqual(
-      "Error: Invalid input: expected string, received undefined: Field callingFunction"
-    );
-  }
+
+    let invalidRuleJSON = JSON.parse(ruleJSON);
+    delete invalidRuleJSON.condition; // Remove condition to make it invalid
+    delete invalidRuleJSON.encodedValues; // Remove encodedValues to make it invalid
+    const parsedRule = validateRuleJSON(JSON.stringify(invalidRuleJSON));
+    expect(isLeft(parsedRule)).toBeTruthy();
+    if (isLeft(parsedRule)) {
+        const errors = unwrapEither(parsedRule);
+        expect(errors.length).toEqual(2);
+        expect(errors[0].message).toEqual("Invalid input: expected string, received undefined: Field condition");
+        expect(errors[1].message).toEqual("Invalid input: expected string, received undefined: Field encodedValues");
+
+    }
 });
+
+test("Can validate foreign call JSON", () => {
+    const parsedFC = validateForeignCallJSON(fcJSON)
+    expect(isRight(parsedFC)).toBeTruthy();
+    if (isRight(parsedFC)) {
+        const fc = unwrapEither(parsedFC);
+
+        expect(fc.valuesToPass).toEqual(JSON.parse(fcJSON).valuesToPass);
+    }
+});
+
+test("Can catch all missing required fields in foreign call JSON", () => {
+    const parsedFC = validateForeignCallJSON("{}")
+    expect(isLeft(parsedFC)).toBeTruthy();
+    if (isLeft(parsedFC)) {
+        const errors = unwrapEither(parsedFC);
+
+        expect(errors.length).toEqual(5);
+        expect(errors[0].message).toEqual("Invalid input: expected string, received undefined: Field name");
+        expect(errors[1].message).toEqual("Invalid input: expected string, received undefined: Field function");
+        expect(errors[2].message).toEqual("Invalid input: expected string, received undefined: Field address");
+        expect(errors[3].message).toEqual("Unsupported return type: Field returnType");
+        expect(errors[4].message).toEqual("Invalid input: expected string, received undefined: Field valuesToPass");
+
+    }
+});
+
+test("Can catch all wrong inputs for fields in foreign call JSON", () => {
+    const invalidJSON = `{
+          "name": 1,
+          "address": 1,
+          "function": 1,
+          "returnType": 1,
+          "valuesToPass": 1
+          }`;
+    const parsedFC = validateForeignCallJSON(invalidJSON)
+    expect(isLeft(parsedFC)).toBeTruthy();
+    if (isLeft(parsedFC)) {
+        const errors = unwrapEither(parsedFC);
+
+        expect(errors.length).toEqual(5);
+        expect(errors[0].message).toEqual("Invalid input: expected string, received number: Field name");
+        expect(errors[1].message).toEqual("Invalid input: expected string, received number: Field function");
+        expect(errors[2].message).toEqual("Invalid input: expected string, received number: Field address");
+        expect(errors[3].message).toEqual("Unsupported return type: Field returnType");
+        expect(errors[4].message).toEqual("Invalid input: expected string, received number: Field valuesToPass");
+
+    }
+});
+
+test("Can return errors if foreign call JSON is invalid", () => {
+    const invalidFCJSON = JSON.parse(fcJSON);
+    invalidFCJSON.name = 100; // Change name to a number to make it invalid
+    const parsedFC = validateForeignCallJSON(JSON.stringify(invalidFCJSON))
+    expect(isLeft(parsedFC)).toBeTruthy();
+    if (isLeft(parsedFC)) {
+        const errors = unwrapEither(parsedFC);
+        expect(errors.length).toEqual(1);
+        expect(errors[0].message).toEqual("Invalid input: expected string, received number: Field name");
+
+    }
+});
+
+test("Can return multiple errors if foreign call JSON is invalid", () => {
+    const invalidFCJSON = JSON.parse(fcJSON);
+    invalidFCJSON.name = 100; // Change name to a number to make it invalid
+    delete invalidFCJSON.valuesToPass; // Remove valuesToPass to make it invalid
+    const parsedFC = validateForeignCallJSON(JSON.stringify(invalidFCJSON))
+    expect(isLeft(parsedFC)).toBeTruthy();
+    if (isLeft(parsedFC)) {
+        const errors = unwrapEither(parsedFC);
+        expect(errors.length).toEqual(2);
+        expect(errors[0].message).toEqual("Invalid input: expected string, received number: Field name");
+        expect(errors[1].message).toEqual("Invalid input: expected string, received undefined: Field valuesToPass");
+
+    }
+});
+
+test("Can validate tracker JSON", () => {
+    const parsedJSON = JSON.parse(trackerJSON);
+    const parsedTracker = validateTrackerJSON(trackerJSON)
+    expect(isRight(parsedTracker)).toBeTruthy();
+    if (isRight(parsedTracker)) {
+        const tracker = unwrapEither(parsedTracker);
+
+        expect(tracker.name).toEqual(parsedJSON.name);
+    }
+});
+
+test("Can catch all missing required fields in tracker JSON", () => {
+    const parsedTracker = validateTrackerJSON("{}")
+    expect(isLeft(parsedTracker)).toBeTruthy();
+    if (isLeft(parsedTracker)) {
+        const errors = unwrapEither(parsedTracker);
+
+        expect(errors.length).toEqual(3);
+        expect(errors[0].message).toEqual("Invalid input: expected string, received undefined: Field name");
+        expect(errors[1].message).toEqual("Unsupported type: Field type");
+        expect(errors[2].message).toEqual("Invalid input: expected string, received undefined: Field initialValue");
+    }
+});
+
+
+test("Can catch all wrong inputs for fields in tracker JSON", () => {
+    const invalidJSON = `{
+              "name": 1,
+              "type": 1,
+              "initialValue": 1
+          }`;
+    const parsedTracker = validateTrackerJSON(invalidJSON)
+    expect(isLeft(parsedTracker)).toBeTruthy();
+    if (isLeft(parsedTracker)) {
+        const errors = unwrapEither(parsedTracker);
+
+        expect(errors.length).toEqual(3);
+        expect(errors[0].message).toEqual("Invalid input: expected string, received number: Field name");
+        expect(errors[1].message).toEqual("Unsupported type: Field type");
+        expect(errors[2].message).toEqual("Invalid input: expected string, received number: Field initialValue");
+    }
+});
+
+test("Can return error if tracker JSON is invalid", () => {
+    const invalidTrackerJSON = JSON.parse(trackerJSON);
+    invalidTrackerJSON.name = 23; // Change name to a number to make it invalid
+    const parsedTracker = validateTrackerJSON(JSON.stringify(invalidTrackerJSON))
+    expect(isLeft(parsedTracker)).toBeTruthy();
+    if (isLeft(parsedTracker)) {
+        const errors = unwrapEither(parsedTracker);
+        expect(errors.length).toEqual(1);
+        expect(errors[0].message).toEqual("Invalid input: expected string, received number: Field name");
+
+    }
+});
+
+test("Can return multiple errors if tracker JSON is invalid", () => {
+    const invalidTrackerJSON = JSON.parse(trackerJSON);
+    invalidTrackerJSON.name = 23; // Change name to a number to make it invalid
+    delete invalidTrackerJSON.initialValue; // Remove initialValue to make it invalid
+    const parsedTracker = validateTrackerJSON(JSON.stringify(invalidTrackerJSON))
+    expect(isLeft(parsedTracker)).toBeTruthy();
+    if (isLeft(parsedTracker)) {
+        const errors = unwrapEither(parsedTracker);
+        expect(errors.length).toEqual(2);
+        expect(errors[0].message).toEqual("Invalid input: expected string, received number: Field name");
+        expect(errors[1].message).toEqual("Invalid input: expected string, received undefined: Field initialValue");
+
+    }
+});
+
+test("Can validate policy JSON", () => {
+    const parsedPolicy = validatePolicyJSON(policyJSON)
+    expect(isRight(parsedPolicy)).toBeTruthy();
+    if (isRight(parsedPolicy)) {
+        const policy = unwrapEither(parsedPolicy);
+        expect(policy.Policy).toEqual(JSON.parse(policyJSON).Policy);
+    }
+});
+
+test("Can catch all missing required fields in policy JSON", () => {
+    const parsedPolicy = validatePolicyJSON("{}")
+    expect(isLeft(parsedPolicy)).toBeTruthy();
+    if (isLeft(parsedPolicy)) {
+        const errors = unwrapEither(parsedPolicy);
+
+        expect(errors.length).toEqual(5);
+        expect(errors[0].message).toEqual("Invalid input: expected string, received undefined: Field Policy");
+        expect(errors[1].message).toEqual("Invalid input: expected string, received undefined: Field PolicyType");
+        expect(errors[2].message).toEqual("Invalid input: expected array, received undefined: Field ForeignCalls");
+        expect(errors[3].message).toEqual("Invalid input: expected array, received undefined: Field Trackers");
+        expect(errors[4].message).toEqual("Invalid input: expected array, received undefined: Field Rules");
+    }
+});
+
+test("Can catch all wrong inputs for fields in policy JSON", () => {
+    const invalidJSON = `
+    {
+    "Policy": 1,
+    "PolicyType": 1,
+    "ForeignCalls": "foo",
+    "Trackers": "bar",
+    "Rules": "baz"
+    }`;
+    const parsedPolicy = validatePolicyJSON(invalidJSON)
+    expect(isLeft(parsedPolicy)).toBeTruthy();
+    if (isLeft(parsedPolicy)) {
+        const errors = unwrapEither(parsedPolicy);
+
+        expect(errors.length).toEqual(5);
+        expect(errors[0].message).toEqual("Invalid input: expected string, received number: Field Policy");
+        expect(errors[1].message).toEqual("Invalid input: expected string, received number: Field PolicyType");
+        expect(errors[2].message).toEqual("Invalid input: expected array, received string: Field ForeignCalls");
+        expect(errors[3].message).toEqual("Invalid input: expected array, received string: Field Trackers");
+        expect(errors[4].message).toEqual("Invalid input: expected array, received string: Field Rules");
+    }
+});
+
+test("Can return error if policy JSON is invalid", () => {
+    const invalidPolicyJSON = JSON.parse(policyJSON);
+    invalidPolicyJSON.Policy = 123; // Change Policy to a number to make it invalid
+    const parsedPolicy = validatePolicyJSON(JSON.stringify(invalidPolicyJSON))
+    expect(isLeft(parsedPolicy)).toBeTruthy();
+    if (isLeft(parsedPolicy)) {
+        const errors = unwrapEither(parsedPolicy);
+        expect(errors[0].message).toEqual("Invalid input: expected string, received number: Field Policy");
+    }
+});
+
+test("Can return multiple errors if policy JSON is invalid", () => {
+    const invalidPolicyJSON = JSON.parse(policyJSON);
+    invalidPolicyJSON.Policy = 123; // Change Policy to a number to make it invalid
+    delete invalidPolicyJSON.PolicyType; // Remove PolicyType to make it invalid
+    const parsedPolicy = validatePolicyJSON(JSON.stringify(invalidPolicyJSON))
+    expect(isLeft(parsedPolicy)).toBeTruthy();
+    if (isLeft(parsedPolicy)) {
+        const errors = unwrapEither(parsedPolicy);
+        expect(errors[0].message).toEqual("Invalid input: expected string, received number: Field Policy");
+        expect(errors[1].message).toEqual("Invalid input: expected string, received undefined: Field PolicyType");
+    }
+});
+
+test("Tests incorrect format for address", () => {
+    var str = `{
+    "name": "Simple Foreign Call",
+    "address": "test",
+    "function": "testSig(address,string,uint256)",
+    "returnType": "uint256",
+    "valuesToPass": "0, 1, 2"
+    }`;
+
+    var retVal = unwrapEither(validateForeignCallJSON(str)) as RulesError[]
+    expect(retVal[0].message).toEqual('Address is invalid: Field address');
+});
+
+test("Tests unsupported return type", () => {
+    var str = `{
+    "name": "Simple Foreign Call",
+    "address": "0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC",
+    "function": "testSig(address,string,uint256)",
+    "returnType": "notAnInt",
+    "valuesToPass": "0, 1, 2"
+    }`;
+    var retVal = unwrapEither(validateForeignCallJSON(str)) as RulesError[]
+    expect(retVal[0].message).toEqual('Unsupported return type: Field returnType');
+});
+
+test("Tests unsupported argument type", () => {
+    var str = `{
+    "name": "Simple Foreign Call",
+    "address": "0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC",
+    "function": "testSig(address,notAnInt,uint256)",
+    "returnType": "uint256",
+    "valuesToPass": "0, 1, 2"
+    }`;
+
+    var retVal = unwrapEither(validateForeignCallJSON(str)) as RulesError[]
+    expect(retVal[0].message).toEqual('Unsupported argument type: Field function');
+});
+
+test("Tests unsupported type", () => {
+    var str = `{
+        "name": "Simple String Tracker",
+        "type": "book",
+        "initialValue": "test"
+        }`;
+    var retVal = unwrapEither(validateTrackerJSON(str)) as RulesError[]
+    expect(retVal[0].message).toEqual('Unsupported type: Field type');
+});
+
+


### PR DESCRIPTION
- added zod validators for input JSON for  Policy, Rule, ForeignCall, and Tracker
- moved all validations in parser functions to validator functions
- added validation tests

- validations NOT included in this ticket but moved to RL-359
  - validate that all created hex strings are less than 32 bytes
  - all opening parenthesis have a closing parenthesis
  - all referenced parameters match a parameter defined in the calling functions encoded values
  - there's only one top level AND/OR
  - each additional set of AND/OR's has its own dedicated set of parenthesis
  - all foreign calls and trackers referenced in the statement exist in the policy 
  
  Possible improvement:
- more informative error messages